### PR TITLE
fix: use natural sorting when sorting by name

### DIFF
--- a/py/services/lora_cache.py
+++ b/py/services/lora_cache.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List, Dict
 from dataclasses import dataclass
 from operator import itemgetter
+from natsort import natsorted
 
 @dataclass
 class LoraCache:
@@ -17,7 +18,7 @@ class LoraCache:
     async def resort(self, name_only: bool = False):
         """Resort all cached data views"""
         async with self._lock:
-            self.sorted_by_name = sorted(
+            self.sorted_by_name = natsorted(
                 self.raw_data, 
                 key=lambda x: x['model_name'].lower()  # Case-insensitive sort
             )

--- a/py/services/model_cache.py
+++ b/py/services/model_cache.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List, Dict
 from dataclasses import dataclass
 from operator import itemgetter
+from natsort import natsorted
 
 @dataclass
 class ModelCache:
@@ -17,7 +18,7 @@ class ModelCache:
     async def resort(self, name_only: bool = False):
         """Resort all cached data views"""
         async with self._lock:
-            self.sorted_by_name = sorted(
+            self.sorted_by_name = natsorted(
                 self.raw_data, 
                 key=lambda x: x['model_name'].lower()  # Case-insensitive sort
             )

--- a/py/services/recipe_cache.py
+++ b/py/services/recipe_cache.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List, Dict
 from dataclasses import dataclass
 from operator import itemgetter
+from natsort import natsorted
 
 @dataclass
 class RecipeCache:
@@ -16,7 +17,7 @@ class RecipeCache:
     async def resort(self, name_only: bool = False):
         """Resort all cached data views"""
         async with self._lock:
-            self.sorted_by_name = sorted(
+            self.sorted_by_name = natsorted(
                 self.raw_data, 
                 key=lambda x: x.get('title', '').lower()  # Case-insensitive sort
             )

--- a/py/services/recipe_scanner.py
+++ b/py/services/recipe_scanner.py
@@ -9,6 +9,7 @@ from .recipe_cache import RecipeCache
 from .service_registry import ServiceRegistry
 from .lora_scanner import LoraScanner
 from ..utils.utils import fuzzy_match
+from natsort import natsorted
 import sys
 
 logger = logging.getLogger(__name__)
@@ -164,7 +165,7 @@ class RecipeScanner:
                 if hasattr(self._cache, "resort"):
                     try:
                         # Sort by name
-                        self._cache.sorted_by_name = sorted(
+                        self._cache.sorted_by_name = natsorted(
                             self._cache.raw_data,
                             key=lambda x: x.get('title', '').lower()
                         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 toml
 numpy
 torch
+natsort


### PR DESCRIPTION
Hi,
Many thanks for your work again! 😄

This PR aims to fix the ordering of the LoRAs, Recipes and Checkpoints when sorted by names.

Currently, the ordering is performed using the `sorted` method, which orders items lexicographically:

- Model 10
- Model 11
- Model 8
- Model 9

![unsorted wall](https://github.com/user-attachments/assets/4c9f4b92-4694-437d-91be-f87678dda652)

![api unsorted](https://github.com/user-attachments/assets/be24d231-d0f1-4a1e-b65f-2562ce4fa7c1)

The proposal is to use a [natural ordering](https://en.wikipedia.org/wiki/Natural_sort_order) instead:

- Adding a dependency to the `natsort` module.
  - https://pypi.org/project/natsort
  - https://github.com/SethMMorton/natsort
- Using `natsorted` instead of `sorted` when ordering by name (drop-in replacement).

Changing the sort to:

- Model 8
- Model 9
- Model 10
- Model 11

![image](https://github.com/user-attachments/assets/bf9355f1-4f3f-4dd8-b407-e86194c48360)

![image](https://github.com/user-attachments/assets/6828f290-8c78-4023-b0a3-60a8386dc1a1)

This works with more complex cases such as below (natural order on the types and versions):

![image](https://github.com/user-attachments/assets/edb435cd-c7d8-4a7a-920d-4d75fdb72b21)