### PR TITLE
[Fix] `/api/chekcpoints/info/{name}` change misspelled method call

### DIFF
--- a/py/routes/checkpoints_routes.py
+++ b/py/routes/checkpoints_routes.py
@@ -430,7 +430,7 @@ class CheckpointsRoutes:
         """Get detailed information for a specific checkpoint by name"""
         try:
             name = request.match_info.get('name', '')
-            checkpoint_info = await self.scanner.get_checkpoint_info_by_name(name)
+            checkpoint_info = await self.scanner.get_model_info_by_name(name)
             
             if checkpoint_info:
                 return web.json_response(checkpoint_info)


### PR DESCRIPTION
If you call:
http://127.0.0.1:8188/api/checkpoints/info/some_name You will get error, that there is no method `get_checkpoint_info_by_name` in `scanner`. Lookslike it wasn't fixed after refactoring or something. Now it works as expected.