### PR TITLE
feat: Add button to select/deselect all filtered LoRAs

### DIFF
--- a/templates/components/controls.html
+++ b/templates/components/controls.html
@@ -103,8 +103,13 @@
 <!-- Add bulk operations panel (initially hidden) -->
 <div id="bulkOperationsPanel" class="bulk-operations-panel hidden">
     <div class="bulk-operations-header">
-        <span id="selectedCount" class="selectable-count" title="Click to view selected items">
-            0 selected <i class="fas fa-caret-down dropdown-caret"></i>
+        <span class="bulk-operations-actions">
+            <span id="selectedCount" class="selectable-count" title="Click to view selected items">
+                0 selected <i class="fas fa-caret-down dropdown-caret"></i>
+            </span>
+            <button onclick="bulkManager.toggleSelectAllLoras()" title="Select/Deselect all filtered LoRAs" class="btn-select-all">
+                <i class="fas fa-solid fa-toggle-off"></i> Toggle All
+            </button>
         </span>
         <div class="bulk-operations-actions">
             <button onclick="bulkManager.sendAllLorasToWorkflow()" title="Send all selected LoRAs to workflow">


### PR DESCRIPTION
hey there.
I wanted a way to select all LoRAs for the current filter, but couldn't find one (or maybe I'm blind)

Anyway, I added a small button to the BulkManager:
![image](https://github.com/user-attachments/assets/d3554014-178e-497e-abae-4e05dfaa57fe)

o7