### PR TITLE
Refactor model route utilities into dedicated services

### DIFF
--- a/py/services/download_coordinator.py
+++ b/py/services/download_coordinator.py
@@ -1,0 +1,100 @@
+"""Service wrapper for coordinating download lifecycle events."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadCoordinator:
+    """Manage download scheduling, cancellation and introspection."""
+
+    def __init__(
+        self,
+        *,
+        ws_manager,
+        download_manager_factory: Callable[[], Awaitable],
+    ) -> None:
+        self._ws_manager = ws_manager
+        self._download_manager_factory = download_manager_factory
+
+    async def schedule_download(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Schedule a download using the provided payload."""
+
+        download_manager = await self._download_manager_factory()
+
+        download_id = payload.get("download_id") or self._ws_manager.generate_download_id()
+        payload.setdefault("download_id", download_id)
+
+        async def progress_callback(progress: Any) -> None:
+            await self._ws_manager.broadcast_download_progress(
+                download_id,
+                {
+                    "status": "progress",
+                    "progress": progress,
+                    "download_id": download_id,
+                },
+            )
+
+        model_id = self._parse_optional_int(payload.get("model_id"), "model_id")
+        model_version_id = self._parse_optional_int(
+            payload.get("model_version_id"), "model_version_id"
+        )
+
+        if model_id is None and model_version_id is None:
+            raise ValueError(
+                "Missing required parameter: Please provide either 'model_id' or 'model_version_id'"
+            )
+
+        result = await download_manager.download_from_civitai(
+            model_id=model_id,
+            model_version_id=model_version_id,
+            save_dir=payload.get("model_root"),
+            relative_path=payload.get("relative_path", ""),
+            use_default_paths=payload.get("use_default_paths", False),
+            progress_callback=progress_callback,
+            download_id=download_id,
+            source=payload.get("source"),
+        )
+
+        result["download_id"] = download_id
+        return result
+
+    async def cancel_download(self, download_id: str) -> Dict[str, Any]:
+        """Cancel an active download and emit a broadcast event."""
+
+        download_manager = await self._download_manager_factory()
+        result = await download_manager.cancel_download(download_id)
+
+        await self._ws_manager.broadcast_download_progress(
+            download_id,
+            {
+                "status": "cancelled",
+                "progress": 0,
+                "download_id": download_id,
+                "message": "Download cancelled by user",
+            },
+        )
+
+        return result
+
+    async def list_active_downloads(self) -> Dict[str, Any]:
+        """Return the active download map from the underlying manager."""
+
+        download_manager = await self._download_manager_factory()
+        return await download_manager.get_active_downloads()
+
+    def _parse_optional_int(self, value: Any, field: str) -> Optional[int]:
+        """Parse an optional integer from user input."""
+
+        if value is None or value == "":
+            return None
+
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid {field}: Must be an integer") from exc
+

--- a/py/services/metadata_sync_service.py
+++ b/py/services/metadata_sync_service.py
@@ -1,0 +1,355 @@
+"""Services for synchronising metadata with remote providers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional
+
+from ..services.settings_manager import SettingsManager
+from ..utils.model_utils import determine_base_model
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataProviderProtocol:
+    """Subset of metadata provider interface consumed by the sync service."""
+
+    async def get_model_by_hash(self, sha256: str) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+        ...
+
+    async def get_model_version(
+        self, model_id: int, model_version_id: Optional[int]
+    ) -> Optional[Dict[str, Any]]:
+        ...
+
+
+class MetadataSyncService:
+    """High level orchestration for metadata synchronisation flows."""
+
+    def __init__(
+        self,
+        *,
+        metadata_manager,
+        preview_service,
+        settings: SettingsManager,
+        default_metadata_provider_factory: Callable[[], Awaitable[MetadataProviderProtocol]],
+        metadata_provider_selector: Callable[[str], Awaitable[MetadataProviderProtocol]],
+    ) -> None:
+        self._metadata_manager = metadata_manager
+        self._preview_service = preview_service
+        self._settings = settings
+        self._get_default_provider = default_metadata_provider_factory
+        self._get_provider = metadata_provider_selector
+
+    async def load_local_metadata(self, metadata_path: str) -> Dict[str, Any]:
+        """Load metadata JSON from disk, returning an empty structure when missing."""
+
+        if not os.path.exists(metadata_path):
+            return {}
+
+        try:
+            with open(metadata_path, "r", encoding="utf-8") as handle:
+                return json.load(handle)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Error loading metadata from %s: %s", metadata_path, exc)
+            return {}
+
+    async def mark_not_found_on_civitai(
+        self, metadata_path: str, local_metadata: Dict[str, Any]
+    ) -> None:
+        """Persist the not-found flag for a metadata payload."""
+
+        local_metadata["from_civitai"] = False
+        await self._metadata_manager.save_metadata(metadata_path, local_metadata)
+
+    @staticmethod
+    def is_civitai_api_metadata(meta: Dict[str, Any]) -> bool:
+        """Determine if the metadata originated from the CivitAI public API."""
+
+        if not isinstance(meta, dict):
+            return False
+        files = meta.get("files")
+        images = meta.get("images")
+        source = meta.get("source")
+        return bool(files) and bool(images) and source != "archive_db"
+
+    async def update_model_metadata(
+        self,
+        metadata_path: str,
+        local_metadata: Dict[str, Any],
+        civitai_metadata: Dict[str, Any],
+        metadata_provider: Optional[MetadataProviderProtocol] = None,
+    ) -> Dict[str, Any]:
+        """Merge remote metadata into the local record and persist the result."""
+
+        existing_civitai = local_metadata.get("civitai") or {}
+
+        if (
+            civitai_metadata.get("source") == "archive_db"
+            and self.is_civitai_api_metadata(existing_civitai)
+        ):
+            logger.info(
+                "Skip civitai update for %s (%s)",
+                local_metadata.get("model_name", ""),
+                existing_civitai.get("name", ""),
+            )
+        else:
+            merged_civitai = existing_civitai.copy()
+            merged_civitai.update(civitai_metadata)
+
+            if civitai_metadata.get("source") == "archive_db":
+                model_name = civitai_metadata.get("model", {}).get("name", "")
+                version_name = civitai_metadata.get("name", "")
+                logger.info(
+                    "Recovered metadata from archive_db for deleted model: %s (%s)",
+                    model_name,
+                    version_name,
+                )
+
+            if "trainedWords" in existing_civitai:
+                existing_trained = existing_civitai.get("trainedWords", [])
+                new_trained = civitai_metadata.get("trainedWords", [])
+                merged_trained = list(set(existing_trained + new_trained))
+                merged_civitai["trainedWords"] = merged_trained
+
+            local_metadata["civitai"] = merged_civitai
+
+        if "model" in civitai_metadata and civitai_metadata["model"]:
+            model_data = civitai_metadata["model"]
+
+            if model_data.get("name"):
+                local_metadata["model_name"] = model_data["name"]
+
+            if not local_metadata.get("modelDescription") and model_data.get("description"):
+                local_metadata["modelDescription"] = model_data["description"]
+
+            if not local_metadata.get("tags") and model_data.get("tags"):
+                local_metadata["tags"] = model_data["tags"]
+
+            if model_data.get("creator") and not local_metadata.get("civitai", {}).get(
+                "creator"
+            ):
+                local_metadata.setdefault("civitai", {})["creator"] = model_data["creator"]
+
+        local_metadata["base_model"] = determine_base_model(
+            civitai_metadata.get("baseModel")
+        )
+
+        await self._preview_service.ensure_preview_for_metadata(
+            metadata_path, local_metadata, civitai_metadata.get("images", [])
+        )
+
+        await self._metadata_manager.save_metadata(metadata_path, local_metadata)
+        return local_metadata
+
+    async def fetch_and_update_model(
+        self,
+        *,
+        sha256: str,
+        file_path: str,
+        model_data: Dict[str, Any],
+        update_cache_func: Callable[[str, str, Dict[str, Any]], Awaitable[bool]],
+    ) -> tuple[bool, Optional[str]]:
+        """Fetch metadata for a model and update both disk and cache state."""
+
+        if not isinstance(model_data, dict):
+            error = f"Invalid model_data type: {type(model_data)}"
+            logger.error(error)
+            return False, error
+
+        metadata_path = os.path.splitext(file_path)[0] + ".metadata.json"
+        enable_archive = self._settings.get("enable_metadata_archive_db", False)
+
+        try:
+            if model_data.get("civitai_deleted") is True:
+                if not enable_archive or model_data.get("db_checked") is True:
+                    return (
+                        False,
+                        "CivitAI model is deleted and metadata archive DB is not enabled",
+                    )
+                metadata_provider = await self._get_provider("sqlite")
+            else:
+                metadata_provider = await self._get_default_provider()
+
+            civitai_metadata, error = await metadata_provider.get_model_by_hash(sha256)
+            if not civitai_metadata:
+                if error == "Model not found":
+                    model_data["from_civitai"] = False
+                    model_data["civitai_deleted"] = True
+                    model_data["db_checked"] = enable_archive
+                    model_data["last_checked_at"] = datetime.now().timestamp()
+
+                    data_to_save = model_data.copy()
+                    data_to_save.pop("folder", None)
+                    await self._metadata_manager.save_metadata(file_path, data_to_save)
+
+                error_msg = (
+                    f"Error fetching metadata: {error} (model_name={model_data.get('model_name', '')})"
+                )
+                logger.error(error_msg)
+                return False, error_msg
+
+            model_data["from_civitai"] = True
+            model_data["civitai_deleted"] = civitai_metadata.get("source") == "archive_db"
+            model_data["db_checked"] = enable_archive
+            model_data["last_checked_at"] = datetime.now().timestamp()
+
+            local_metadata = model_data.copy()
+            local_metadata.pop("folder", None)
+
+            await self.update_model_metadata(
+                metadata_path,
+                local_metadata,
+                civitai_metadata,
+                metadata_provider,
+            )
+
+            update_payload = {
+                "model_name": local_metadata.get("model_name"),
+                "preview_url": local_metadata.get("preview_url"),
+                "civitai": local_metadata.get("civitai"),
+            }
+            model_data.update(update_payload)
+
+            await update_cache_func(file_path, file_path, local_metadata)
+            return True, None
+        except KeyError as exc:
+            error_msg = f"Error fetching metadata - Missing key: {exc} in model_data={model_data}"
+            logger.error(error_msg)
+            return False, error_msg
+        except Exception as exc:  # pragma: no cover - error path
+            error_msg = f"Error fetching metadata: {exc}"
+            logger.error(error_msg, exc_info=True)
+            return False, error_msg
+
+    async def fetch_metadata_by_sha(
+        self, sha256: str, metadata_provider: Optional[MetadataProviderProtocol] = None
+    ) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """Fetch metadata for a SHA256 hash from the configured provider."""
+
+        provider = metadata_provider or await self._get_default_provider()
+        return await provider.get_model_by_hash(sha256)
+
+    async def relink_metadata(
+        self,
+        *,
+        file_path: str,
+        metadata: Dict[str, Any],
+        model_id: int,
+        model_version_id: Optional[int],
+    ) -> Dict[str, Any]:
+        """Relink a local metadata record to a specific CivitAI model version."""
+
+        provider = await self._get_default_provider()
+        civitai_metadata = await provider.get_model_version(model_id, model_version_id)
+        if not civitai_metadata:
+            raise ValueError(
+                f"Model version not found on CivitAI for ID: {model_id}"
+                + (f" with version: {model_version_id}" if model_version_id else "")
+            )
+
+        primary_model_file: Optional[Dict[str, Any]] = None
+        for file_info in civitai_metadata.get("files", []):
+            if file_info.get("primary", False) and file_info.get("type") == "Model":
+                primary_model_file = file_info
+                break
+
+        if primary_model_file and primary_model_file.get("hashes", {}).get("SHA256"):
+            metadata["sha256"] = primary_model_file["hashes"]["SHA256"].lower()
+
+        metadata_path = os.path.splitext(file_path)[0] + ".metadata.json"
+        await self.update_model_metadata(
+            metadata_path,
+            metadata,
+            civitai_metadata,
+            provider,
+        )
+
+        return metadata
+
+    async def save_metadata_updates(
+        self,
+        *,
+        file_path: str,
+        updates: Dict[str, Any],
+        metadata_loader: Callable[[str], Awaitable[Dict[str, Any]]],
+        update_cache: Callable[[str, str, Dict[str, Any]], Awaitable[bool]],
+    ) -> Dict[str, Any]:
+        """Apply metadata updates and persist to disk and cache."""
+
+        metadata_path = os.path.splitext(file_path)[0] + ".metadata.json"
+        metadata = await metadata_loader(metadata_path)
+
+        for key, value in updates.items():
+            if isinstance(value, dict) and isinstance(metadata.get(key), dict):
+                metadata[key].update(value)
+            else:
+                metadata[key] = value
+
+        await self._metadata_manager.save_metadata(file_path, metadata)
+        await update_cache(file_path, file_path, metadata)
+
+        if "model_name" in updates:
+            logger.debug("Metadata update touched model_name; cache resort required")
+
+        return metadata
+
+    async def verify_duplicate_hashes(
+        self,
+        *,
+        file_paths: Iterable[str],
+        metadata_loader: Callable[[str], Awaitable[Dict[str, Any]]],
+        hash_calculator: Callable[[str], Awaitable[str]],
+        update_cache: Callable[[str, str, Dict[str, Any]], Awaitable[bool]],
+    ) -> Dict[str, Any]:
+        """Verify a collection of files share the same SHA256 hash."""
+
+        file_paths = list(file_paths)
+        if not file_paths:
+            raise ValueError("No file paths provided for verification")
+
+        results = {
+            "verified_as_duplicates": True,
+            "mismatched_files": [],
+            "new_hash_map": {},
+        }
+
+        expected_hash: Optional[str] = None
+        first_metadata_path = os.path.splitext(file_paths[0])[0] + ".metadata.json"
+        first_metadata = await metadata_loader(first_metadata_path)
+        if first_metadata and "sha256" in first_metadata:
+            expected_hash = first_metadata["sha256"].lower()
+
+        for path in file_paths:
+            if not os.path.exists(path):
+                continue
+
+            try:
+                actual_hash = await hash_calculator(path)
+                metadata_path = os.path.splitext(path)[0] + ".metadata.json"
+                metadata = await metadata_loader(metadata_path)
+                stored_hash = metadata.get("sha256", "").lower()
+
+                if not expected_hash:
+                    expected_hash = stored_hash
+
+                if actual_hash != expected_hash:
+                    results["verified_as_duplicates"] = False
+                    results["mismatched_files"].append(path)
+                    results["new_hash_map"][path] = actual_hash
+
+                if actual_hash != stored_hash:
+                    metadata["sha256"] = actual_hash
+                    await self._metadata_manager.save_metadata(path, metadata)
+                    await update_cache(path, path, metadata)
+            except Exception as exc:  # pragma: no cover - defensive path
+                logger.error("Error verifying hash for %s: %s", path, exc)
+                results["mismatched_files"].append(path)
+                results["new_hash_map"][path] = "error_calculating_hash"
+                results["verified_as_duplicates"] = False
+
+        return results
+

--- a/py/services/preview_asset_service.py
+++ b/py/services/preview_asset_service.py
@@ -1,0 +1,168 @@
+"""Service for processing preview assets for models."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Awaitable, Callable, Dict, Optional, Sequence
+
+from ..utils.constants import CARD_PREVIEW_WIDTH, PREVIEW_EXTENSIONS
+
+logger = logging.getLogger(__name__)
+
+
+class PreviewAssetService:
+    """Manage fetching and persisting preview assets."""
+
+    def __init__(
+        self,
+        *,
+        metadata_manager,
+        downloader_factory: Callable[[], Awaitable],
+        exif_utils,
+    ) -> None:
+        self._metadata_manager = metadata_manager
+        self._downloader_factory = downloader_factory
+        self._exif_utils = exif_utils
+
+    async def ensure_preview_for_metadata(
+        self,
+        metadata_path: str,
+        local_metadata: Dict[str, object],
+        images: Sequence[Dict[str, object]] | None,
+    ) -> None:
+        """Ensure preview assets exist for the supplied metadata entry."""
+
+        if local_metadata.get("preview_url") and os.path.exists(
+            str(local_metadata["preview_url"])
+        ):
+            return
+
+        if not images:
+            return
+
+        first_preview = images[0]
+        base_name = os.path.splitext(os.path.splitext(os.path.basename(metadata_path))[0])[0]
+        preview_dir = os.path.dirname(metadata_path)
+        is_video = first_preview.get("type") == "video"
+
+        if is_video:
+            extension = ".mp4"
+            preview_path = os.path.join(preview_dir, base_name + extension)
+            downloader = await self._downloader_factory()
+            success, result = await downloader.download_file(
+                first_preview["url"], preview_path, use_auth=False
+            )
+            if success:
+                local_metadata["preview_url"] = preview_path.replace(os.sep, "/")
+                local_metadata["preview_nsfw_level"] = first_preview.get("nsfwLevel", 0)
+        else:
+            extension = ".webp"
+            preview_path = os.path.join(preview_dir, base_name + extension)
+            downloader = await self._downloader_factory()
+            success, content, _headers = await downloader.download_to_memory(
+                first_preview["url"], use_auth=False
+            )
+            if not success:
+                return
+
+            try:
+                optimized_data, _ = self._exif_utils.optimize_image(
+                    image_data=content,
+                    target_width=CARD_PREVIEW_WIDTH,
+                    format="webp",
+                    quality=85,
+                    preserve_metadata=False,
+                )
+                with open(preview_path, "wb") as handle:
+                    handle.write(optimized_data)
+            except Exception as exc:  # pragma: no cover - defensive path
+                logger.error("Error optimizing preview image: %s", exc)
+                try:
+                    with open(preview_path, "wb") as handle:
+                        handle.write(content)
+                except Exception as save_exc:
+                    logger.error("Error saving preview image: %s", save_exc)
+                    return
+
+            local_metadata["preview_url"] = preview_path.replace(os.sep, "/")
+            local_metadata["preview_nsfw_level"] = first_preview.get("nsfwLevel", 0)
+
+    async def replace_preview(
+        self,
+        *,
+        model_path: str,
+        preview_data: bytes,
+        content_type: str,
+        original_filename: Optional[str],
+        nsfw_level: int,
+        update_preview_in_cache: Callable[[str, str, int], Awaitable[bool]],
+        metadata_loader: Callable[[str], Awaitable[Dict[str, object]]],
+    ) -> Dict[str, object]:
+        """Replace an existing preview asset for a model."""
+
+        base_name = os.path.splitext(os.path.basename(model_path))[0]
+        folder = os.path.dirname(model_path)
+
+        extension, optimized_data = await self._convert_preview(
+            preview_data, content_type, original_filename
+        )
+
+        for ext in PREVIEW_EXTENSIONS:
+            existing_preview = os.path.join(folder, base_name + ext)
+            if os.path.exists(existing_preview):
+                try:
+                    os.remove(existing_preview)
+                except Exception as exc:  # pragma: no cover - defensive path
+                    logger.warning(
+                        "Failed to delete existing preview %s: %s", existing_preview, exc
+                    )
+
+        preview_path = os.path.join(folder, base_name + extension).replace(os.sep, "/")
+        with open(preview_path, "wb") as handle:
+            handle.write(optimized_data)
+
+        metadata_path = os.path.splitext(model_path)[0] + ".metadata.json"
+        metadata = await metadata_loader(metadata_path)
+        metadata["preview_url"] = preview_path
+        metadata["preview_nsfw_level"] = nsfw_level
+        await self._metadata_manager.save_metadata(model_path, metadata)
+
+        await update_preview_in_cache(model_path, preview_path, nsfw_level)
+
+        return {"preview_path": preview_path, "preview_nsfw_level": nsfw_level}
+
+    async def _convert_preview(
+        self, data: bytes, content_type: str, original_filename: Optional[str]
+    ) -> tuple[str, bytes]:
+        """Convert preview bytes to the persisted representation."""
+
+        if content_type.startswith("video/"):
+            extension = self._resolve_video_extension(content_type, original_filename)
+            return extension, data
+
+        original_ext = (original_filename or "").lower()
+        if original_ext.endswith(".gif") or content_type.lower() == "image/gif":
+            return ".gif", data
+
+        optimized_data, _ = self._exif_utils.optimize_image(
+            image_data=data,
+            target_width=CARD_PREVIEW_WIDTH,
+            format="webp",
+            quality=85,
+            preserve_metadata=False,
+        )
+        return ".webp", optimized_data
+
+    def _resolve_video_extension(self, content_type: str, original_filename: Optional[str]) -> str:
+        """Infer the best extension for a video preview."""
+
+        if original_filename:
+            extension = os.path.splitext(original_filename)[1].lower()
+            if extension in {".mp4", ".webm", ".mov", ".avi"}:
+                return extension
+
+        if "webm" in content_type:
+            return ".webm"
+        return ".mp4"
+

--- a/py/services/tag_update_service.py
+++ b/py/services/tag_update_service.py
@@ -1,0 +1,47 @@
+"""Service for updating tag collections on metadata records."""
+
+from __future__ import annotations
+
+import os
+
+from typing import Awaitable, Callable, Dict, List, Sequence
+
+
+class TagUpdateService:
+    """Encapsulate tag manipulation for models."""
+
+    def __init__(self, *, metadata_manager) -> None:
+        self._metadata_manager = metadata_manager
+
+    async def add_tags(
+        self,
+        *,
+        file_path: str,
+        new_tags: Sequence[str],
+        metadata_loader: Callable[[str], Awaitable[Dict[str, object]]],
+        update_cache: Callable[[str, str, Dict[str, object]], Awaitable[bool]],
+    ) -> List[str]:
+        """Add tags to a metadata entry while keeping case-insensitive uniqueness."""
+
+        base, _ = os.path.splitext(file_path)
+        metadata_path = f"{base}.metadata.json"
+        metadata = await metadata_loader(metadata_path)
+
+        existing_tags = list(metadata.get("tags", []))
+        existing_lower = [tag.lower() for tag in existing_tags]
+
+        tags_added: List[str] = []
+        for tag in new_tags:
+            if isinstance(tag, str) and tag.strip():
+                normalized = tag.strip()
+                if normalized.lower() not in existing_lower:
+                    existing_tags.append(normalized)
+                    existing_lower.append(normalized.lower())
+                    tags_added.append(normalized)
+
+        metadata["tags"] = existing_tags
+        await self._metadata_manager.save_metadata(file_path, metadata)
+        await update_cache(file_path, file_path, metadata)
+
+        return existing_tags
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,8 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+# Register async marker for coroutine-style tests
+markers =
+    asyncio: execute test within asyncio event loop
 # Skip problematic directories to avoid import conflicts
 norecursedirs = .git .tox dist build *.egg __pycache__ py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import types
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
+import asyncio
+import inspect
 from unittest import mock
 import sys
 
@@ -37,6 +39,13 @@ nodes_mock.LoraLoader = mock.MagicMock()
 nodes_mock.SaveImage = mock.MagicMock()
 nodes_mock.NODE_CLASS_MAPPINGS = {}
 sys.modules['nodes'] = nodes_mock
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    if inspect.iscoroutinefunction(pyfuncitem.function):
+        asyncio.run(pyfuncitem.obj(**pyfuncitem.funcargs))
+        return True
+    return None
 
 
 @dataclass

--- a/tests/services/test_base_model_service.py
+++ b/tests/services/test_base_model_service.py
@@ -1,8 +1,35 @@
 ﻿import pytest
 
-from py.services.base_model_service import BaseModelService
-from py.services.model_query import ModelCacheRepository, ModelFilterSet, SearchStrategy, SortParams
-from py.utils.models import BaseModelMetadata
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def import_from(module_name: str):
+    existing = sys.modules.get("py")
+    if existing is None or getattr(existing, "__file__", "") != str(ROOT / "py/__init__.py"):
+        sys.modules.pop("py", None)
+        spec = importlib.util.spec_from_file_location("py", ROOT / "py/__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        module.__path__ = [str(ROOT / "py")]
+        sys.modules["py"] = module
+    return importlib.import_module(module_name)
+
+
+BaseModelService = import_from("py.services.base_model_service").BaseModelService
+model_query_module = import_from("py.services.model_query")
+ModelCacheRepository = model_query_module.ModelCacheRepository
+ModelFilterSet = model_query_module.ModelFilterSet
+SearchStrategy = model_query_module.SearchStrategy
+SortParams = model_query_module.SortParams
+BaseModelMetadata = import_from("py.utils.models").BaseModelMetadata
 
 
 class StubSettings:

--- a/tests/services/test_route_support_services.py
+++ b/tests/services/test_route_support_services.py
@@ -1,0 +1,273 @@
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import importlib
+import importlib.util
+
+import pytest
+
+
+def import_from(module_name: str):
+    existing = sys.modules.get("py")
+    if existing is None or getattr(existing, "__file__", "") != str(ROOT / "py/__init__.py"):
+        sys.modules.pop("py", None)
+        spec = importlib.util.spec_from_file_location("py", ROOT / "py/__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        module.__path__ = [str(ROOT / "py")]
+        sys.modules["py"] = module
+    return importlib.import_module(module_name)
+
+
+DownloadCoordinator = import_from("py.services.download_coordinator").DownloadCoordinator
+MetadataSyncService = import_from("py.services.metadata_sync_service").MetadataSyncService
+PreviewAssetService = import_from("py.services.preview_asset_service").PreviewAssetService
+TagUpdateService = import_from("py.services.tag_update_service").TagUpdateService
+
+
+class DummySettings:
+    def __init__(self, values: Dict[str, Any] | None = None) -> None:
+        self._values = values or {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+class RecordingMetadataManager:
+    def __init__(self) -> None:
+        self.saved: List[tuple[str, Dict[str, Any]]] = []
+
+    async def save_metadata(self, path: str, metadata: Dict[str, Any]) -> bool:
+        self.saved.append((path, json.loads(json.dumps(metadata))))
+        metadata_path = path if path.endswith(".metadata.json") else f"{os.path.splitext(path)[0]}.metadata.json"
+        Path(metadata_path).write_text(json.dumps(metadata))
+        return True
+
+
+class RecordingPreviewService:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, List[Dict[str, Any]]]] = []
+
+    async def ensure_preview_for_metadata(
+        self, metadata_path: str, local_metadata: Dict[str, Any], images
+    ) -> None:
+        self.calls.append((metadata_path, list(images or [])))
+        local_metadata["preview_url"] = "preview.webp"
+        local_metadata["preview_nsfw_level"] = 1
+
+
+class DummyProvider:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self.payload = payload
+
+    async def get_model_by_hash(self, sha256: str):
+        return self.payload, None
+
+    async def get_model_version(self, model_id: int, model_version_id: int | None):
+        return self.payload
+
+
+class FakeExifUtils:
+    @staticmethod
+    def optimize_image(**kwargs):
+        return kwargs["image_data"], {}
+
+
+def test_metadata_sync_merges_remote_fields(tmp_path: Path) -> None:
+    manager = RecordingMetadataManager()
+    preview = RecordingPreviewService()
+    provider = DummyProvider({
+        "baseModel": "SD15",
+        "model": {"name": "Merged", "description": "desc", "tags": ["tag"], "creator": {"username": "user"}},
+        "trainedWords": ["word"],
+        "images": [{"url": "http://example", "nsfwLevel": 2, "type": "image"}],
+    })
+
+    service = MetadataSyncService(
+        metadata_manager=manager,
+        preview_service=preview,
+        settings=DummySettings(),
+        default_metadata_provider_factory=lambda: asyncio.sleep(0, result=provider),
+        metadata_provider_selector=lambda _name=None: asyncio.sleep(0, result=provider),
+    )
+
+    metadata_path = str(tmp_path / "model.metadata.json")
+    local_metadata = {"civitai": {"trainedWords": ["existing"]}}
+
+    updated = asyncio.run(service.update_model_metadata(metadata_path, local_metadata, provider.payload))
+
+    assert updated["model_name"] == "Merged"
+    assert updated["modelDescription"] == "desc"
+    assert set(updated["civitai"]["trainedWords"]) == {"existing", "word"}
+    assert manager.saved
+    assert preview.calls
+
+
+def test_metadata_sync_fetch_and_update_updates_cache(tmp_path: Path) -> None:
+    manager = RecordingMetadataManager()
+    preview = RecordingPreviewService()
+    provider = DummyProvider({
+        "baseModel": "SDXL",
+        "model": {"name": "Updated"},
+        "images": [],
+    })
+
+    update_cache_calls: List[Dict[str, Any]] = []
+
+    async def update_cache(original: str, new: str, metadata: Dict[str, Any]) -> bool:
+        update_cache_calls.append({"original": original, "metadata": metadata})
+        return True
+
+    service = MetadataSyncService(
+        metadata_manager=manager,
+        preview_service=preview,
+        settings=DummySettings(),
+        default_metadata_provider_factory=lambda: asyncio.sleep(0, result=provider),
+        metadata_provider_selector=lambda _name=None: asyncio.sleep(0, result=provider),
+    )
+
+    model_data = {"sha256": "abc", "file_path": str(tmp_path / "model.safetensors")}
+    success, error = asyncio.run(
+        service.fetch_and_update_model(
+            sha256="abc",
+            file_path=str(tmp_path / "model.safetensors"),
+            model_data=model_data,
+            update_cache_func=update_cache,
+        )
+    )
+
+    assert success is True
+    assert error is None
+    assert update_cache_calls
+    assert manager.saved
+
+
+def test_preview_asset_service_replace_preview(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "sample.metadata.json"
+    metadata_path.write_text(json.dumps({}))
+
+    async def metadata_loader(path: str) -> Dict[str, Any]:
+        return json.loads(Path(path).read_text())
+
+    manager = RecordingMetadataManager()
+
+    service = PreviewAssetService(
+        metadata_manager=manager,
+        downloader_factory=lambda: asyncio.sleep(0, result=None),
+        exif_utils=FakeExifUtils(),
+    )
+
+    preview_calls: List[Dict[str, Any]] = []
+
+    async def update_preview(model_path: str, preview_path: str, nsfw: int) -> bool:
+        preview_calls.append({"model_path": model_path, "preview_path": preview_path, "nsfw": nsfw})
+        return True
+
+    model_path = str(tmp_path / "sample.safetensors")
+    Path(model_path).write_bytes(b"model")
+
+    result = asyncio.run(
+        service.replace_preview(
+            model_path=model_path,
+            preview_data=b"image-bytes",
+            content_type="image/png",
+            original_filename="preview.png",
+            nsfw_level=2,
+            update_preview_in_cache=update_preview,
+            metadata_loader=metadata_loader,
+        )
+    )
+
+    assert result["preview_nsfw_level"] == 2
+    assert preview_calls
+    saved_metadata = json.loads(metadata_path.read_text())
+    assert saved_metadata["preview_nsfw_level"] == 2
+
+
+def test_download_coordinator_emits_progress() -> None:
+    class WSStub:
+        def __init__(self) -> None:
+            self.progress_events: List[Dict[str, Any]] = []
+            self.counter = 0
+
+        def generate_download_id(self) -> str:
+            self.counter += 1
+            return f"dl-{self.counter}"
+
+        async def broadcast_download_progress(self, download_id: str, payload: Dict[str, Any]) -> None:
+            self.progress_events.append({"id": download_id, **payload})
+
+    class DownloadManagerStub:
+        def __init__(self) -> None:
+            self.calls: List[Dict[str, Any]] = []
+
+        async def download_from_civitai(self, **kwargs) -> Dict[str, Any]:
+            self.calls.append(kwargs)
+            await kwargs["progress_callback"](10)
+            return {"success": True}
+
+        async def cancel_download(self, download_id: str) -> Dict[str, Any]:
+            return {"success": True, "download_id": download_id}
+
+        async def get_active_downloads(self) -> Dict[str, Any]:
+            return {"active": []}
+
+    ws_stub = WSStub()
+    manager_stub = DownloadManagerStub()
+
+    coordinator = DownloadCoordinator(
+        ws_manager=ws_stub,
+        download_manager_factory=lambda: asyncio.sleep(0, result=manager_stub),
+    )
+
+    result = asyncio.run(coordinator.schedule_download({"model_id": 1}))
+
+    assert result["success"] is True
+    assert manager_stub.calls
+    assert ws_stub.progress_events
+
+    cancel_result = asyncio.run(coordinator.cancel_download(result["download_id"]))
+    assert cancel_result["success"] is True
+
+    active = asyncio.run(coordinator.list_active_downloads())
+    assert active == {"active": []}
+
+
+def test_tag_update_service_adds_unique_tags(tmp_path: Path) -> None:
+    metadata_path = tmp_path / "model.metadata.json"
+    metadata_path.write_text(json.dumps({"tags": ["Existing"]}))
+
+    async def loader(path: str) -> Dict[str, Any]:
+        return json.loads(Path(path).read_text())
+
+    manager = RecordingMetadataManager()
+
+    service = TagUpdateService(metadata_manager=manager)
+
+    cache_updates: List[Dict[str, Any]] = []
+
+    async def update_cache(original: str, new: str, metadata: Dict[str, Any]) -> bool:
+        cache_updates.append(metadata)
+        return True
+
+    tags = asyncio.run(
+        service.add_tags(
+            file_path=str(tmp_path / "model.safetensors"),
+            new_tags=["New", "existing"],
+            metadata_loader=loader,
+            update_cache=update_cache,
+        )
+    )
+
+    assert tags == ["Existing", "New"]
+    assert manager.saved
+    assert cache_updates


### PR DESCRIPTION
## Summary
- extract metadata syncing, preview asset handling, download coordination, and tag updates into dedicated service classes
- wire the new services into model route handlers and example metadata refresh logic while keeping shared helpers lightweight
- add focused unit tests for the new services and register coroutine test support for pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d016a0174c8320bdd966ba57de986f