### PR TITLE
feat(routes): extract orchestration use cases

### DIFF
--- a/py/services/use_cases/__init__.py
+++ b/py/services/use_cases/__init__.py
@@ -1,0 +1,25 @@
+"""Application-level orchestration services for model routes."""
+
+from .auto_organize_use_case import (
+    AutoOrganizeInProgressError,
+    AutoOrganizeUseCase,
+)
+from .bulk_metadata_refresh_use_case import (
+    BulkMetadataRefreshUseCase,
+    MetadataRefreshProgressReporter,
+)
+from .download_model_use_case import (
+    DownloadModelEarlyAccessError,
+    DownloadModelUseCase,
+    DownloadModelValidationError,
+)
+
+__all__ = [
+    "AutoOrganizeInProgressError",
+    "AutoOrganizeUseCase",
+    "BulkMetadataRefreshUseCase",
+    "MetadataRefreshProgressReporter",
+    "DownloadModelEarlyAccessError",
+    "DownloadModelUseCase",
+    "DownloadModelValidationError",
+]

--- a/py/services/use_cases/auto_organize_use_case.py
+++ b/py/services/use_cases/auto_organize_use_case.py
@@ -1,0 +1,56 @@
+"""Auto-organize use case orchestrating concurrency and progress handling."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional, Protocol, Sequence
+
+from ..model_file_service import AutoOrganizeResult, ModelFileService, ProgressCallback
+
+
+class AutoOrganizeLockProvider(Protocol):
+    """Minimal protocol for objects exposing auto-organize locking primitives."""
+
+    def is_auto_organize_running(self) -> bool:
+        """Return ``True`` when an auto-organize operation is in-flight."""
+
+    async def get_auto_organize_lock(self) -> asyncio.Lock:
+        """Return the asyncio lock guarding auto-organize operations."""
+
+
+class AutoOrganizeInProgressError(RuntimeError):
+    """Raised when an auto-organize run is already active."""
+
+
+class AutoOrganizeUseCase:
+    """Coordinate auto-organize execution behind a shared lock."""
+
+    def __init__(
+        self,
+        *,
+        file_service: ModelFileService,
+        lock_provider: AutoOrganizeLockProvider,
+    ) -> None:
+        self._file_service = file_service
+        self._lock_provider = lock_provider
+
+    async def execute(
+        self,
+        *,
+        file_paths: Optional[Sequence[str]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> AutoOrganizeResult:
+        """Run the auto-organize routine guarded by a shared lock."""
+
+        if self._lock_provider.is_auto_organize_running():
+            raise AutoOrganizeInProgressError("Auto-organize is already running")
+
+        lock = await self._lock_provider.get_auto_organize_lock()
+        if lock.locked():
+            raise AutoOrganizeInProgressError("Auto-organize is already running")
+
+        async with lock:
+            return await self._file_service.auto_organize_models(
+                file_paths=list(file_paths) if file_paths is not None else None,
+                progress_callback=progress_callback,
+            )

--- a/py/services/use_cases/bulk_metadata_refresh_use_case.py
+++ b/py/services/use_cases/bulk_metadata_refresh_use_case.py
@@ -1,0 +1,122 @@
+"""Use case encapsulating the bulk metadata refresh orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Protocol, Sequence
+
+from ..metadata_sync_service import MetadataSyncService
+
+
+class MetadataRefreshProgressReporter(Protocol):
+    """Protocol for progress reporters used during metadata refresh."""
+
+    async def on_progress(self, payload: Dict[str, Any]) -> None:
+        """Handle a metadata refresh progress update."""
+
+
+class BulkMetadataRefreshUseCase:
+    """Coordinate bulk metadata refreshes with progress emission."""
+
+    def __init__(
+        self,
+        *,
+        service,
+        metadata_sync: MetadataSyncService,
+        settings_service,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._service = service
+        self._metadata_sync = metadata_sync
+        self._settings = settings_service
+        self._logger = logger or logging.getLogger(__name__)
+
+    async def execute(
+        self,
+        *,
+        progress_callback: Optional[MetadataRefreshProgressReporter] = None,
+    ) -> Dict[str, Any]:
+        """Refresh metadata for all qualifying models."""
+
+        cache = await self._service.scanner.get_cached_data()
+        total_models = len(cache.raw_data)
+
+        enable_metadata_archive_db = self._settings.get("enable_metadata_archive_db", False)
+        to_process: Sequence[Dict[str, Any]] = [
+            model
+            for model in cache.raw_data
+            if model.get("sha256")
+            and (not model.get("civitai") or not model["civitai"].get("id"))
+            and (
+                (enable_metadata_archive_db and not model.get("db_checked", False))
+                or (not enable_metadata_archive_db and model.get("from_civitai") is True)
+            )
+        ]
+
+        total_to_process = len(to_process)
+        processed = 0
+        success = 0
+        needs_resort = False
+
+        async def emit(status: str, **extra: Any) -> None:
+            if progress_callback is None:
+                return
+            payload = {"status": status, "total": total_to_process, "processed": processed, "success": success}
+            payload.update(extra)
+            await progress_callback.on_progress(payload)
+
+        await emit("started")
+
+        for model in to_process:
+            try:
+                original_name = model.get("model_name")
+                result, _ = await self._metadata_sync.fetch_and_update_model(
+                    sha256=model["sha256"],
+                    file_path=model["file_path"],
+                    model_data=model,
+                    update_cache_func=self._service.scanner.update_single_model_cache,
+                )
+                if result:
+                    success += 1
+                    if original_name != model.get("model_name"):
+                        needs_resort = True
+                processed += 1
+                await emit(
+                    "processing",
+                    processed=processed,
+                    success=success,
+                    current_name=model.get("model_name", "Unknown"),
+                )
+            except Exception as exc:  # pragma: no cover - logging path
+                processed += 1
+                self._logger.error(
+                    "Error fetching CivitAI data for %s: %s",
+                    model.get("file_path"),
+                    exc,
+                )
+
+        if needs_resort:
+            await cache.resort()
+
+        await emit("completed", processed=processed, success=success)
+
+        message = (
+            "Successfully updated "
+            f"{success} of {processed} processed {self._service.model_type}s (total: {total_models})"
+        )
+
+        return {"success": True, "message": message, "processed": processed, "updated": success, "total": total_models}
+
+    async def execute_with_error_handling(
+        self,
+        *,
+        progress_callback: Optional[MetadataRefreshProgressReporter] = None,
+    ) -> Dict[str, Any]:
+        """Wrapper providing progress notification on unexpected failures."""
+
+        try:
+            return await self.execute(progress_callback=progress_callback)
+        except Exception as exc:
+            if progress_callback is not None:
+                await progress_callback.on_progress({"status": "error", "error": str(exc)})
+            raise

--- a/py/services/use_cases/download_model_use_case.py
+++ b/py/services/use_cases/download_model_use_case.py
@@ -1,0 +1,37 @@
+"""Use case for scheduling model downloads with consistent error handling."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..download_coordinator import DownloadCoordinator
+
+
+class DownloadModelValidationError(ValueError):
+    """Raised when incoming payload validation fails."""
+
+
+class DownloadModelEarlyAccessError(RuntimeError):
+    """Raised when the download is gated behind Civitai early access."""
+
+
+class DownloadModelUseCase:
+    """Coordinate download scheduling through the coordinator service."""
+
+    def __init__(self, *, download_coordinator: DownloadCoordinator) -> None:
+        self._download_coordinator = download_coordinator
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Schedule a download and normalize error conditions."""
+
+        try:
+            return await self._download_coordinator.schedule_download(payload)
+        except ValueError as exc:
+            raise DownloadModelValidationError(str(exc)) from exc
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            message = str(exc)
+            if "401" in message:
+                raise DownloadModelEarlyAccessError(
+                    "Early Access Restriction: This model requires purchase. Please buy early access on Civitai.com."
+                ) from exc
+            raise

--- a/py/services/websocket_progress_callback.py
+++ b/py/services/websocket_progress_callback.py
@@ -1,11 +1,29 @@
-from typing import Dict, Any
+"""Progress callback implementations backed by the shared WebSocket manager."""
+
+from typing import Any, Dict, Protocol
+
 from .model_file_service import ProgressCallback
 from .websocket_manager import ws_manager
 
 
-class WebSocketProgressCallback(ProgressCallback):
-    """WebSocket implementation of progress callback"""
-    
+class ProgressReporter(Protocol):
+    """Protocol representing an async progress callback."""
+
     async def on_progress(self, progress_data: Dict[str, Any]) -> None:
-        """Send progress data via WebSocket"""
+        """Handle a progress update payload."""
+
+
+class WebSocketProgressCallback(ProgressCallback):
+    """WebSocket implementation of progress callback."""
+
+    async def on_progress(self, progress_data: Dict[str, Any]) -> None:
+        """Send progress data via WebSocket."""
         await ws_manager.broadcast_auto_organize_progress(progress_data)
+
+
+class WebSocketBroadcastCallback:
+    """Generic WebSocket progress callback broadcasting to all clients."""
+
+    async def on_progress(self, progress_data: Dict[str, Any]) -> None:
+        """Send the provided payload to all connected clients."""
+        await ws_manager.broadcast(progress_data)

--- a/tests/services/test_use_cases.py
+++ b/tests/services/test_use_cases.py
@@ -1,0 +1,191 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from py_local.services.model_file_service import AutoOrganizeResult
+from py_local.services.use_cases import (
+    AutoOrganizeInProgressError,
+    AutoOrganizeUseCase,
+    BulkMetadataRefreshUseCase,
+    DownloadModelEarlyAccessError,
+    DownloadModelUseCase,
+    DownloadModelValidationError,
+)
+from tests.conftest import MockModelService, MockScanner
+
+
+class StubLockProvider:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self.running = False
+
+    def is_auto_organize_running(self) -> bool:
+        return self.running
+
+    async def get_auto_organize_lock(self) -> asyncio.Lock:
+        return self._lock
+
+
+class StubFileService:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def auto_organize_models(
+        self,
+        *,
+        file_paths: Optional[List[str]] = None,
+        progress_callback=None,
+    ) -> AutoOrganizeResult:
+        result = AutoOrganizeResult()
+        result.total = len(file_paths or [])
+        self.calls.append({"file_paths": file_paths, "progress_callback": progress_callback})
+        return result
+
+
+class StubMetadataSync:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def fetch_and_update_model(self, **kwargs: Any):
+        self.calls.append(kwargs)
+        model_data = kwargs["model_data"]
+        model_data["model_name"] = model_data.get("model_name", "model") + "-updated"
+        return True, None
+
+
+@dataclass
+class StubSettings:
+    enable_metadata_archive_db: bool = False
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key == "enable_metadata_archive_db":
+            return self.enable_metadata_archive_db
+        return default
+
+
+class ProgressCollector:
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    async def on_progress(self, payload: Dict[str, Any]) -> None:
+        self.events.append(payload)
+
+
+class StubDownloadCoordinator:
+    def __init__(self, *, error: Optional[str] = None) -> None:
+        self.error = error
+        self.payloads: List[Dict[str, Any]] = []
+
+    async def schedule_download(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self.payloads.append(payload)
+        if self.error == "validation":
+            raise ValueError("Missing required parameter: Please provide either 'model_id' or 'model_version_id'")
+        if self.error == "401":
+            raise RuntimeError("401 Unauthorized")
+        return {"success": True, "download_id": "abc123"}
+
+
+async def test_auto_organize_use_case_executes_with_lock() -> None:
+    file_service = StubFileService()
+    lock_provider = StubLockProvider()
+    use_case = AutoOrganizeUseCase(file_service=file_service, lock_provider=lock_provider)
+
+    result = await use_case.execute(file_paths=["model1"], progress_callback=None)
+
+    assert isinstance(result, AutoOrganizeResult)
+    assert file_service.calls[0]["file_paths"] == ["model1"]
+
+
+async def test_auto_organize_use_case_rejects_when_running() -> None:
+    file_service = StubFileService()
+    lock_provider = StubLockProvider()
+    lock_provider.running = True
+    use_case = AutoOrganizeUseCase(file_service=file_service, lock_provider=lock_provider)
+
+    with pytest.raises(AutoOrganizeInProgressError):
+        await use_case.execute(file_paths=None, progress_callback=None)
+
+
+async def test_bulk_metadata_refresh_emits_progress_and_updates_cache() -> None:
+    scanner = MockScanner()
+    scanner._cache.raw_data = [
+        {
+            "file_path": "model1.safetensors",
+            "sha256": "hash",
+            "from_civitai": True,
+            "model_name": "Demo",
+        }
+    ]
+    service = MockModelService(scanner)
+    metadata_sync = StubMetadataSync()
+    settings = StubSettings()
+    progress = ProgressCollector()
+
+    use_case = BulkMetadataRefreshUseCase(
+        service=service,
+        metadata_sync=metadata_sync,
+        settings_service=settings,
+        logger=logging.getLogger("test"),
+    )
+
+    result = await use_case.execute_with_error_handling(progress_callback=progress)
+
+    assert result["success"] is True
+    assert progress.events[0]["status"] == "started"
+    assert progress.events[-1]["status"] == "completed"
+    assert metadata_sync.calls
+    assert scanner._cache.resort_calls == 1
+
+
+async def test_bulk_metadata_refresh_reports_errors() -> None:
+    class FailingScanner(MockScanner):
+        async def get_cached_data(self, force_refresh: bool = False):
+            raise RuntimeError("boom")
+
+    service = MockModelService(FailingScanner())
+    metadata_sync = StubMetadataSync()
+    settings = StubSettings()
+    progress = ProgressCollector()
+
+    use_case = BulkMetadataRefreshUseCase(
+        service=service,
+        metadata_sync=metadata_sync,
+        settings_service=settings,
+        logger=logging.getLogger("test"),
+    )
+
+    with pytest.raises(RuntimeError):
+        await use_case.execute_with_error_handling(progress_callback=progress)
+
+    assert progress.events
+    assert progress.events[-1]["status"] == "error"
+    assert progress.events[-1]["error"] == "boom"
+
+
+async def test_download_model_use_case_raises_validation_error() -> None:
+    coordinator = StubDownloadCoordinator(error="validation")
+    use_case = DownloadModelUseCase(download_coordinator=coordinator)
+
+    with pytest.raises(DownloadModelValidationError):
+        await use_case.execute({})
+
+
+async def test_download_model_use_case_raises_early_access() -> None:
+    coordinator = StubDownloadCoordinator(error="401")
+    use_case = DownloadModelUseCase(download_coordinator=coordinator)
+
+    with pytest.raises(DownloadModelEarlyAccessError):
+        await use_case.execute({"model_id": 1})
+
+
+async def test_download_model_use_case_returns_result() -> None:
+    coordinator = StubDownloadCoordinator()
+    use_case = DownloadModelUseCase(download_coordinator=coordinator)
+
+    result = await use_case.execute({"model_id": 1})
+
+    assert result["success"] is True
+    assert result["download_id"] == "abc123"


### PR DESCRIPTION
## Summary
- extract auto organize, download, and metadata refresh orchestration into dedicated use cases with pluggable progress callbacks
- update route handlers to call the new services and expose websocket-friendly progress hooks
- extend route and service tests to cover conflict scenarios and progress emission

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01c9d1b1c8320b5e6a1b3687aa186