### PR TITLE
feat: expose recipe scanner mutation APIs

### DIFF
--- a/py/services/recipe_cache.py
+++ b/py/services/recipe_cache.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict
+from typing import Iterable, List, Dict, Optional
 from dataclasses import dataclass
 from operator import itemgetter
 from natsort import natsorted
@@ -10,77 +10,115 @@ class RecipeCache:
     raw_data: List[Dict]
     sorted_by_name: List[Dict]
     sorted_by_date: List[Dict]
-    
+
     def __post_init__(self):
         self._lock = asyncio.Lock()
 
     async def resort(self, name_only: bool = False):
         """Resort all cached data views"""
         async with self._lock:
-            self.sorted_by_name = natsorted(
-                self.raw_data, 
-                key=lambda x: x.get('title', '').lower()  # Case-insensitive sort
-            )
-            if not name_only:
-                self.sorted_by_date = sorted(
-                    self.raw_data, 
-                    key=itemgetter('created_date', 'file_path'), 
-                    reverse=True
-                )
-    
-    async def update_recipe_metadata(self, recipe_id: str, metadata: Dict) -> bool:
+            self._resort_locked(name_only=name_only)
+
+    async def update_recipe_metadata(self, recipe_id: str, metadata: Dict, *, resort: bool = True) -> bool:
         """Update metadata for a specific recipe in all cached data
-        
+
         Args:
             recipe_id: The ID of the recipe to update
             metadata: The new metadata
-            
+
         Returns:
             bool: True if the update was successful, False if the recipe wasn't found
         """
+        async with self._lock:
+            for item in self.raw_data:
+                if str(item.get('id')) == str(recipe_id):
+                    item.update(metadata)
+                    if resort:
+                        self._resort_locked()
+                    return True
+        return False  # Recipe not found
 
-        # Update in raw_data
-        for item in self.raw_data:
-            if item.get('id') == recipe_id:
-                item.update(metadata)
-                break
-        else:
-            return False  # Recipe not found
-            
-        # Resort to reflect changes
-        await self.resort()
-        return True
-            
-    async def add_recipe(self, recipe_data: Dict) -> None:
-        """Add a new recipe to the cache
-        
-        Args:
-            recipe_data: The recipe data to add
-        """
+    async def add_recipe(self, recipe_data: Dict, *, resort: bool = False) -> None:
+        """Add a new recipe to the cache."""
+
         async with self._lock:
             self.raw_data.append(recipe_data)
-            await self.resort() 
+            if resort:
+                self._resort_locked()
 
-    async def remove_recipe(self, recipe_id: str) -> bool:
-        """Remove a recipe from the cache by ID
-        
+    async def remove_recipe(self, recipe_id: str, *, resort: bool = False) -> Optional[Dict]:
+        """Remove a recipe from the cache by ID.
+
         Args:
             recipe_id: The ID of the recipe to remove
-            
+
         Returns:
-            bool: True if the recipe was found and removed, False otherwise
+            The removed recipe data if found, otherwise ``None``.
         """
-        # Find the recipe in raw_data
-        recipe_index = next((i for i, recipe in enumerate(self.raw_data) 
-                             if recipe.get('id') == recipe_id), None)
-        
-        if recipe_index is None:
-            return False
-        
-        # Remove from raw_data
-        self.raw_data.pop(recipe_index)
-        
-        # Resort to update sorted lists
-        await self.resort()
-        
-        return True 
+
+        async with self._lock:
+            for index, recipe in enumerate(self.raw_data):
+                if str(recipe.get('id')) == str(recipe_id):
+                    removed = self.raw_data.pop(index)
+                    if resort:
+                        self._resort_locked()
+                    return removed
+        return None
+
+    async def bulk_remove(self, recipe_ids: Iterable[str], *, resort: bool = False) -> List[Dict]:
+        """Remove multiple recipes from the cache."""
+
+        id_set = {str(recipe_id) for recipe_id in recipe_ids}
+        if not id_set:
+            return []
+
+        async with self._lock:
+            removed = [item for item in self.raw_data if str(item.get('id')) in id_set]
+            if not removed:
+                return []
+
+            self.raw_data = [item for item in self.raw_data if str(item.get('id')) not in id_set]
+            if resort:
+                self._resort_locked()
+            return removed
+
+    async def replace_recipe(self, recipe_id: str, new_data: Dict, *, resort: bool = False) -> bool:
+        """Replace cached data for a recipe."""
+
+        async with self._lock:
+            for index, recipe in enumerate(self.raw_data):
+                if str(recipe.get('id')) == str(recipe_id):
+                    self.raw_data[index] = new_data
+                    if resort:
+                        self._resort_locked()
+                    return True
+        return False
+
+    async def get_recipe(self, recipe_id: str) -> Optional[Dict]:
+        """Return a shallow copy of a cached recipe."""
+
+        async with self._lock:
+            for recipe in self.raw_data:
+                if str(recipe.get('id')) == str(recipe_id):
+                    return dict(recipe)
+        return None
+
+    async def snapshot(self) -> List[Dict]:
+        """Return a copy of all cached recipes."""
+
+        async with self._lock:
+            return [dict(item) for item in self.raw_data]
+
+    def _resort_locked(self, *, name_only: bool = False) -> None:
+        """Sort cached views. Caller must hold ``_lock``."""
+
+        self.sorted_by_name = natsorted(
+            self.raw_data,
+            key=lambda x: x.get('title', '').lower()
+        )
+        if not name_only:
+            self.sorted_by_date = sorted(
+                self.raw_data,
+                key=itemgetter('created_date', 'file_path'),
+                reverse=True
+            )

--- a/py/services/recipes/sharing_service.py
+++ b/py/services/recipes/sharing_service.py
@@ -38,11 +38,7 @@ class RecipeSharingService:
     async def share_recipe(self, *, recipe_scanner, recipe_id: str) -> SharingResult:
         """Prepare a temporary downloadable copy of a recipe image."""
 
-        cache = await recipe_scanner.get_cached_data()
-        recipe = next(
-            (r for r in getattr(cache, "raw_data", []) if str(r.get("id", "")) == recipe_id),
-            None,
-        )
+        recipe = await recipe_scanner.get_recipe_by_id(recipe_id)
         if not recipe:
             raise RecipeNotFoundError("Recipe not found")
 
@@ -81,11 +77,7 @@ class RecipeSharingService:
             self._cleanup_entry(recipe_id)
             raise RecipeNotFoundError("Shared recipe file not found")
 
-        cache = await recipe_scanner.get_cached_data()
-        recipe = next(
-            (r for r in getattr(cache, "raw_data", []) if str(r.get("id", "")) == recipe_id),
-            None,
-        )
+        recipe = await recipe_scanner.get_recipe_by_id(recipe_id)
         filename_base = (
             f"recipe_{recipe.get('title', '').replace(' ', '_').lower()}" if recipe else recipe_id
         )

--- a/tests/services/test_recipe_scanner.py
+++ b/tests/services/test_recipe_scanner.py
@@ -1,0 +1,185 @@
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from py.config import config
+from py.services.recipe_scanner import RecipeScanner
+from py.utils.utils import calculate_recipe_fingerprint
+
+
+class StubHashIndex:
+    def __init__(self) -> None:
+        self._hash_to_path: dict[str, str] = {}
+
+    def get_path(self, hash_value: str) -> str | None:
+        return self._hash_to_path.get(hash_value)
+
+
+class StubLoraScanner:
+    def __init__(self) -> None:
+        self._hash_index = StubHashIndex()
+        self._hash_meta: dict[str, dict[str, str]] = {}
+        self._models_by_name: dict[str, dict] = {}
+        self._cache = SimpleNamespace(raw_data=[])
+
+    async def get_cached_data(self):
+        return self._cache
+
+    def has_hash(self, hash_value: str) -> bool:
+        return hash_value.lower() in self._hash_meta
+
+    def get_preview_url_by_hash(self, hash_value: str) -> str:
+        meta = self._hash_meta.get(hash_value.lower())
+        return meta.get("preview_url", "") if meta else ""
+
+    def get_path_by_hash(self, hash_value: str) -> str | None:
+        meta = self._hash_meta.get(hash_value.lower())
+        return meta.get("path") if meta else None
+
+    async def get_model_info_by_name(self, name: str):
+        return self._models_by_name.get(name)
+
+    def register_model(self, name: str, info: dict) -> None:
+        self._models_by_name[name] = info
+        hash_value = (info.get("sha256") or "").lower()
+        if hash_value:
+            self._hash_meta[hash_value] = {
+                "path": info.get("file_path", ""),
+                "preview_url": info.get("preview_url", ""),
+            }
+            self._hash_index._hash_to_path[hash_value] = info.get("file_path", "")
+        self._cache.raw_data.append({
+            "sha256": info.get("sha256", ""),
+            "path": info.get("file_path", ""),
+            "civitai": info.get("civitai", {}),
+        })
+
+
+@pytest.fixture
+def recipe_scanner(tmp_path: Path, monkeypatch):
+    RecipeScanner._instance = None
+    monkeypatch.setattr(config, "loras_roots", [str(tmp_path)])
+    stub = StubLoraScanner()
+    scanner = RecipeScanner(lora_scanner=stub)
+    asyncio.run(scanner.refresh_cache(force=True))
+    yield scanner, stub
+    RecipeScanner._instance = None
+
+
+async def test_add_recipe_during_concurrent_reads(recipe_scanner):
+    scanner, _ = recipe_scanner
+
+    initial_recipe = {
+        "id": "one",
+        "file_path": "path/a.png",
+        "title": "First",
+        "modified": 1.0,
+        "created_date": 1.0,
+        "loras": [],
+    }
+    await scanner.add_recipe(initial_recipe)
+
+    new_recipe = {
+        "id": "two",
+        "file_path": "path/b.png",
+        "title": "Second",
+        "modified": 2.0,
+        "created_date": 2.0,
+        "loras": [],
+    }
+
+    async def reader_task():
+        for _ in range(5):
+            cache = await scanner.get_cached_data()
+            _ = [item["id"] for item in cache.raw_data]
+            await asyncio.sleep(0)
+
+    await asyncio.gather(reader_task(), reader_task(), scanner.add_recipe(new_recipe))
+    await asyncio.sleep(0)
+    cache = await scanner.get_cached_data()
+
+    assert {item["id"] for item in cache.raw_data} == {"one", "two"}
+    assert len(cache.sorted_by_name) == len(cache.raw_data)
+
+
+async def test_remove_recipe_during_reads(recipe_scanner):
+    scanner, _ = recipe_scanner
+
+    recipe_ids = ["alpha", "beta", "gamma"]
+    for index, recipe_id in enumerate(recipe_ids):
+        await scanner.add_recipe({
+            "id": recipe_id,
+            "file_path": f"path/{recipe_id}.png",
+            "title": recipe_id,
+            "modified": float(index),
+            "created_date": float(index),
+            "loras": [],
+        })
+
+    async def reader_task():
+        for _ in range(5):
+            cache = await scanner.get_cached_data()
+            _ = list(cache.sorted_by_date)
+            await asyncio.sleep(0)
+
+    await asyncio.gather(reader_task(), scanner.remove_recipe("beta"))
+    await asyncio.sleep(0)
+    cache = await scanner.get_cached_data()
+
+    assert {item["id"] for item in cache.raw_data} == {"alpha", "gamma"}
+
+
+async def test_update_lora_entry_updates_cache_and_file(tmp_path: Path, recipe_scanner):
+    scanner, stub = recipe_scanner
+    recipes_dir = Path(config.loras_roots[0]) / "recipes"
+    recipes_dir.mkdir(parents=True, exist_ok=True)
+
+    recipe_id = "recipe-1"
+    recipe_path = recipes_dir / f"{recipe_id}.recipe.json"
+    recipe_data = {
+        "id": recipe_id,
+        "file_path": str(tmp_path / "image.png"),
+        "title": "Original",
+        "modified": 0.0,
+        "created_date": 0.0,
+        "loras": [
+            {"file_name": "old", "strength": 1.0, "hash": "", "isDeleted": True, "exclude": True},
+        ],
+    }
+    recipe_path.write_text(json.dumps(recipe_data))
+
+    await scanner.add_recipe(dict(recipe_data))
+
+    target_hash = "abc123"
+    target_info = {
+        "sha256": target_hash,
+        "file_path": str(tmp_path / "loras" / "target.safetensors"),
+        "preview_url": "preview.png",
+        "civitai": {"id": 42, "name": "v1", "model": {"name": "Target"}},
+    }
+    stub.register_model("target", target_info)
+
+    updated_recipe, updated_lora = await scanner.update_lora_entry(
+        recipe_id,
+        0,
+        target_name="target",
+        target_lora=target_info,
+    )
+
+    assert updated_lora["inLibrary"] is True
+    assert updated_lora["localPath"] == target_info["file_path"]
+    assert updated_lora["hash"] == target_hash
+
+    with recipe_path.open("r", encoding="utf-8") as file_obj:
+        persisted = json.load(file_obj)
+
+    expected_fingerprint = calculate_recipe_fingerprint(persisted["loras"])
+    assert persisted["fingerprint"] == expected_fingerprint
+
+    cache = await scanner.get_cached_data()
+    cached_recipe = next(item for item in cache.raw_data if item["id"] == recipe_id)
+    assert cached_recipe["loras"][0]["hash"] == target_hash
+    assert cached_recipe["fingerprint"] == expected_fingerprint

--- a/tests/services/test_recipe_services.py
+++ b/tests/services/test_recipe_services.py
@@ -108,6 +108,10 @@ async def test_save_recipe_reports_duplicates(tmp_path):
             self.last_fingerprint = fingerprint
             return ["existing"]
 
+        async def add_recipe(self, recipe_data):
+            self._cache.raw_data.append(recipe_data)
+            await self._cache.resort()
+
     scanner = DummyScanner(tmp_path)
     service = RecipePersistenceService(
         exif_utils=exif_utils,


### PR DESCRIPTION
## Summary
- add background-resorting cache helpers in `RecipeCache` and new mutation APIs on `RecipeScanner`
- update recipe persistence, sharing, and query flows to call the new scanner methods instead of private attributes
- add regression tests covering concurrent recipe cache mutations through the public scanner interface

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0df98b71883209eff5b1fc5145afc