### PR TITLE
feat(example-images): add use case orchestration

### DIFF
--- a/py/routes/example_images_routes.py
+++ b/py/routes/example_images_routes.py
@@ -12,6 +12,10 @@ from .handlers.example_images_handlers import (
     ExampleImagesHandlerSet,
     ExampleImagesManagementHandler,
 )
+from ..services.use_cases.example_images import (
+    DownloadExampleImagesUseCase,
+    ImportExampleImagesUseCase,
+)
 from ..utils.example_images_download_manager import DownloadManager
 from ..utils.example_images_file_manager import ExampleImagesFileManager
 from ..utils.example_images_processor import ExampleImagesProcessor
@@ -59,8 +63,10 @@ class ExampleImagesRoutes:
 
     def _build_handler_set(self) -> ExampleImagesHandlerSet:
         logger.debug("Building ExampleImagesHandlerSet with %s, %s, %s", self._download_manager, self._processor, self._file_manager)
-        download_handler = ExampleImagesDownloadHandler(self._download_manager)
-        management_handler = ExampleImagesManagementHandler(self._processor)
+        download_use_case = DownloadExampleImagesUseCase(download_manager=self._download_manager)
+        download_handler = ExampleImagesDownloadHandler(download_use_case, self._download_manager)
+        import_use_case = ImportExampleImagesUseCase(processor=self._processor)
+        management_handler = ExampleImagesManagementHandler(import_use_case, self._processor)
         file_handler = ExampleImagesFileHandler(self._file_manager)
         return ExampleImagesHandlerSet(
             download=download_handler,

--- a/py/routes/handlers/example_images_handlers.py
+++ b/py/routes/handlers/example_images_handlers.py
@@ -6,37 +6,101 @@ from typing import Callable, Mapping
 
 from aiohttp import web
 
+from ...services.use_cases.example_images import (
+    DownloadExampleImagesConfigurationError,
+    DownloadExampleImagesInProgressError,
+    DownloadExampleImagesUseCase,
+    ImportExampleImagesUseCase,
+    ImportExampleImagesValidationError,
+)
+from ...utils.example_images_download_manager import (
+    DownloadConfigurationError,
+    DownloadInProgressError,
+    DownloadNotRunningError,
+    ExampleImagesDownloadError,
+)
+from ...utils.example_images_processor import ExampleImagesImportError
+
 
 class ExampleImagesDownloadHandler:
     """HTTP adapters for download-related example image endpoints."""
 
-    def __init__(self, download_manager) -> None:
+    def __init__(
+        self,
+        download_use_case: DownloadExampleImagesUseCase,
+        download_manager,
+    ) -> None:
+        self._download_use_case = download_use_case
         self._download_manager = download_manager
 
     async def download_example_images(self, request: web.Request) -> web.StreamResponse:
-        return await self._download_manager.start_download(request)
+        try:
+            payload = await request.json()
+            result = await self._download_use_case.execute(payload)
+            return web.json_response(result)
+        except DownloadExampleImagesInProgressError as exc:
+            response = {
+                'success': False,
+                'error': str(exc),
+                'status': exc.progress,
+            }
+            return web.json_response(response, status=400)
+        except DownloadExampleImagesConfigurationError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=400)
+        except ExampleImagesDownloadError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=500)
 
     async def get_example_images_status(self, request: web.Request) -> web.StreamResponse:
-        return await self._download_manager.get_status(request)
+        result = await self._download_manager.get_status(request)
+        return web.json_response(result)
 
     async def pause_example_images(self, request: web.Request) -> web.StreamResponse:
-        return await self._download_manager.pause_download(request)
+        try:
+            result = await self._download_manager.pause_download(request)
+            return web.json_response(result)
+        except DownloadNotRunningError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=400)
 
     async def resume_example_images(self, request: web.Request) -> web.StreamResponse:
-        return await self._download_manager.resume_download(request)
+        try:
+            result = await self._download_manager.resume_download(request)
+            return web.json_response(result)
+        except DownloadNotRunningError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=400)
 
     async def force_download_example_images(self, request: web.Request) -> web.StreamResponse:
-        return await self._download_manager.start_force_download(request)
+        try:
+            payload = await request.json()
+            result = await self._download_manager.start_force_download(payload)
+            return web.json_response(result)
+        except DownloadInProgressError as exc:
+            response = {
+                'success': False,
+                'error': str(exc),
+                'status': exc.progress_snapshot,
+            }
+            return web.json_response(response, status=400)
+        except DownloadConfigurationError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=400)
+        except ExampleImagesDownloadError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=500)
 
 
 class ExampleImagesManagementHandler:
     """HTTP adapters for import/delete endpoints."""
 
-    def __init__(self, processor) -> None:
+    def __init__(self, import_use_case: ImportExampleImagesUseCase, processor) -> None:
+        self._import_use_case = import_use_case
         self._processor = processor
 
     async def import_example_images(self, request: web.Request) -> web.StreamResponse:
-        return await self._processor.import_images(request)
+        try:
+            result = await self._import_use_case.execute(request)
+            return web.json_response(result)
+        except ImportExampleImagesValidationError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=400)
+        except ExampleImagesImportError as exc:
+            return web.json_response({'success': False, 'error': str(exc)}, status=500)
 
     async def delete_example_image(self, request: web.Request) -> web.StreamResponse:
         return await self._processor.delete_custom_image(request)

--- a/py/services/use_cases/__init__.py
+++ b/py/services/use_cases/__init__.py
@@ -13,6 +13,13 @@ from .download_model_use_case import (
     DownloadModelUseCase,
     DownloadModelValidationError,
 )
+from .example_images import (
+    DownloadExampleImagesConfigurationError,
+    DownloadExampleImagesInProgressError,
+    DownloadExampleImagesUseCase,
+    ImportExampleImagesUseCase,
+    ImportExampleImagesValidationError,
+)
 
 __all__ = [
     "AutoOrganizeInProgressError",
@@ -22,4 +29,9 @@ __all__ = [
     "DownloadModelEarlyAccessError",
     "DownloadModelUseCase",
     "DownloadModelValidationError",
+    "DownloadExampleImagesConfigurationError",
+    "DownloadExampleImagesInProgressError",
+    "DownloadExampleImagesUseCase",
+    "ImportExampleImagesUseCase",
+    "ImportExampleImagesValidationError",
 ]

--- a/py/services/use_cases/example_images/__init__.py
+++ b/py/services/use_cases/example_images/__init__.py
@@ -1,0 +1,19 @@
+"""Example image specific use case exports."""
+
+from .download_example_images_use_case import (
+    DownloadExampleImagesUseCase,
+    DownloadExampleImagesInProgressError,
+    DownloadExampleImagesConfigurationError,
+)
+from .import_example_images_use_case import (
+    ImportExampleImagesUseCase,
+    ImportExampleImagesValidationError,
+)
+
+__all__ = [
+    "DownloadExampleImagesUseCase",
+    "DownloadExampleImagesInProgressError",
+    "DownloadExampleImagesConfigurationError",
+    "ImportExampleImagesUseCase",
+    "ImportExampleImagesValidationError",
+]

--- a/py/services/use_cases/example_images/download_example_images_use_case.py
+++ b/py/services/use_cases/example_images/download_example_images_use_case.py
@@ -1,0 +1,42 @@
+"""Use case coordinating example image downloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ....utils.example_images_download_manager import (
+    DownloadConfigurationError,
+    DownloadInProgressError,
+    ExampleImagesDownloadError,
+)
+
+
+class DownloadExampleImagesInProgressError(RuntimeError):
+    """Raised when a download is already running."""
+
+    def __init__(self, progress: Dict[str, Any]) -> None:
+        super().__init__("Download already in progress")
+        self.progress = progress
+
+
+class DownloadExampleImagesConfigurationError(ValueError):
+    """Raised when settings prevent downloads from starting."""
+
+
+class DownloadExampleImagesUseCase:
+    """Validate payloads and trigger the download manager."""
+
+    def __init__(self, *, download_manager) -> None:
+        self._download_manager = download_manager
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Start a download and translate manager errors."""
+
+        try:
+            return await self._download_manager.start_download(payload)
+        except DownloadInProgressError as exc:
+            raise DownloadExampleImagesInProgressError(exc.progress_snapshot) from exc
+        except DownloadConfigurationError as exc:
+            raise DownloadExampleImagesConfigurationError(str(exc)) from exc
+        except ExampleImagesDownloadError:
+            raise

--- a/py/services/use_cases/example_images/import_example_images_use_case.py
+++ b/py/services/use_cases/example_images/import_example_images_use_case.py
@@ -1,0 +1,86 @@
+"""Use case for importing example images."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import suppress
+from typing import Any, Dict, List
+
+from aiohttp import web
+
+from ....utils.example_images_processor import (
+    ExampleImagesImportError,
+    ExampleImagesProcessor,
+    ExampleImagesValidationError,
+)
+
+
+class ImportExampleImagesValidationError(ValueError):
+    """Raised when request validation fails."""
+
+
+class ImportExampleImagesUseCase:
+    """Parse upload payloads and delegate to the processor service."""
+
+    def __init__(self, *, processor: ExampleImagesProcessor) -> None:
+        self._processor = processor
+
+    async def execute(self, request: web.Request) -> Dict[str, Any]:
+        model_hash: str | None = None
+        files_to_import: List[str] = []
+        temp_files: List[str] = []
+
+        try:
+            if request.content_type and "multipart/form-data" in request.content_type:
+                reader = await request.multipart()
+
+                first_field = await reader.next()
+                if first_field and first_field.name == "model_hash":
+                    model_hash = await first_field.text()
+                else:
+                    # Support clients that send files first and hash later
+                    if first_field is not None:
+                        await self._collect_upload_file(first_field, files_to_import, temp_files)
+
+                async for field in reader:
+                    if field.name == "model_hash" and not model_hash:
+                        model_hash = await field.text()
+                    elif field.name == "files":
+                        await self._collect_upload_file(field, files_to_import, temp_files)
+            else:
+                data = await request.json()
+                model_hash = data.get("model_hash")
+                files_to_import = list(data.get("file_paths", []))
+
+            result = await self._processor.import_images(model_hash, files_to_import)
+            return result
+        except ExampleImagesValidationError as exc:
+            raise ImportExampleImagesValidationError(str(exc)) from exc
+        except ExampleImagesImportError:
+            raise
+        finally:
+            for path in temp_files:
+                with suppress(Exception):
+                    os.remove(path)
+
+    async def _collect_upload_file(
+        self,
+        field: Any,
+        files_to_import: List[str],
+        temp_files: List[str],
+    ) -> None:
+        """Persist an uploaded file to disk and add it to the import list."""
+
+        filename = field.filename or "upload"
+        file_ext = os.path.splitext(filename)[1].lower()
+
+        with tempfile.NamedTemporaryFile(suffix=file_ext, delete=False) as tmp_file:
+            temp_files.append(tmp_file.name)
+            while True:
+                chunk = await field.read_chunk()
+                if not chunk:
+                    break
+                tmp_file.write(chunk)
+
+        files_to_import.append(tmp_file.name)


### PR DESCRIPTION
## Summary
- introduce dedicated example image download and import use cases and wire them through the aiohttp handlers
- refactor the download manager and processor to return plain data structures and raise typed errors for use case consumption
- update route and use case tests to cover the new validation and progress handling paths

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d21501c3d08320b1cb639cd928a29e