### PR TITLE
refactor: convert example image download manager to service instance

### DIFF
--- a/py/routes/example_images_routes.py
+++ b/py/routes/example_images_routes.py
@@ -16,7 +16,10 @@ from ..services.use_cases.example_images import (
     DownloadExampleImagesUseCase,
     ImportExampleImagesUseCase,
 )
-from ..utils.example_images_download_manager import DownloadManager
+from ..utils.example_images_download_manager import (
+    DownloadManager,
+    get_default_download_manager,
+)
 from ..utils.example_images_file_manager import ExampleImagesFileManager
 from ..utils.example_images_processor import ExampleImagesProcessor
 
@@ -29,11 +32,11 @@ class ExampleImagesRoutes:
     def __init__(
         self,
         *,
-        download_manager=DownloadManager,
+        download_manager: DownloadManager | None = None,
         processor=ExampleImagesProcessor,
         file_manager=ExampleImagesFileManager,
     ) -> None:
-        self._download_manager = download_manager
+        self._download_manager = download_manager or get_default_download_manager()
         self._processor = processor
         self._file_manager = file_manager
         self._handler_set: ExampleImagesHandlerSet | None = None


### PR DESCRIPTION
## Summary
- convert the example image download manager into an instantiable service that tracks progress per instance and expose a default singleton for reuse
- update example image routes to inject the shared manager instance into use cases and handlers
- allow metadata refreshing to accept an optional progress dictionary so it can update instance-managed tracking

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d224db253c83208649803ef748bb9f