### PR TITLE
refactor: align example image downloads with websocket manager

### DIFF
--- a/py/lora_manager.py
+++ b/py/lora_manager.py
@@ -166,7 +166,7 @@ class LoraManager:
         RecipeRoutes.setup_routes(app)
         UpdateRoutes.setup_routes(app)  
         MiscRoutes.setup_routes(app)
-        ExampleImagesRoutes.setup_routes(app)
+        ExampleImagesRoutes.setup_routes(app, ws_manager=ws_manager)
         
         # Setup WebSocket routes that are shared across all model types
         app.router.add_get('/ws/fetch-progress', ws_manager.handle_connection)

--- a/py/routes/example_images_routes.py
+++ b/py/routes/example_images_routes.py
@@ -32,21 +32,24 @@ class ExampleImagesRoutes:
     def __init__(
         self,
         *,
+        ws_manager,
         download_manager: DownloadManager | None = None,
         processor=ExampleImagesProcessor,
         file_manager=ExampleImagesFileManager,
     ) -> None:
-        self._download_manager = download_manager or get_default_download_manager()
+        if ws_manager is None:
+            raise ValueError("ws_manager is required")
+        self._download_manager = download_manager or get_default_download_manager(ws_manager)
         self._processor = processor
         self._file_manager = file_manager
         self._handler_set: ExampleImagesHandlerSet | None = None
         self._handler_mapping: Mapping[str, Callable[[web.Request], web.StreamResponse]] | None = None
 
     @classmethod
-    def setup_routes(cls, app: web.Application) -> None:
+    def setup_routes(cls, app: web.Application, *, ws_manager) -> None:
         """Register routes on the given aiohttp application using default wiring."""
 
-        controller = cls()
+        controller = cls(ws_manager=ws_manager)
         controller.register(app)
 
     def register(self, app: web.Application) -> None:

--- a/standalone.py
+++ b/standalone.py
@@ -421,7 +421,7 @@ class StandaloneLoraManager(LoraManager):
         RecipeRoutes.setup_routes(app)
         UpdateRoutes.setup_routes(app)
         MiscRoutes.setup_routes(app)
-        ExampleImagesRoutes.setup_routes(app)
+        ExampleImagesRoutes.setup_routes(app, ws_manager=ws_manager)
 
         # Setup WebSocket routes that are shared across all model types
         app.router.add_get('/ws/fetch-progress', ws_manager.handle_connection)

--- a/tests/routes/test_example_images_routes.py
+++ b/tests/routes/test_example_images_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
@@ -88,6 +88,14 @@ class StubExampleImagesFileManager:
         return web.json_response({"operation": "has_images", "query": dict(request.query)})
 
 
+class StubWebSocketManager:
+    def __init__(self) -> None:
+        self.broadcast_calls: List[Dict[str, Any]] = []
+
+    async def broadcast(self, payload: Dict[str, Any]) -> None:
+        self.broadcast_calls.append(payload)
+
+
 @asynccontextmanager
 async def example_images_app() -> ExampleImagesHarness:
     """Yield an ExampleImagesRoutes app wired with stubbed collaborators."""
@@ -95,8 +103,10 @@ async def example_images_app() -> ExampleImagesHarness:
     download_manager = StubDownloadManager()
     processor = StubExampleImagesProcessor()
     file_manager = StubExampleImagesFileManager()
+    ws_manager = StubWebSocketManager()
 
     controller = ExampleImagesRoutes(
+        ws_manager=ws_manager,
         download_manager=download_manager,
         processor=processor,
         file_manager=file_manager,


### PR DESCRIPTION
## Summary
- inject the websocket manager into the example image download manager and expose a shared singleton helper
- broadcast consistent progress updates for bulk and forced downloads while protecting state changes behind a lock
- wire routes, startup code, and tests to supply the shared websocket manager instance

## Testing
- python -m pytest tests/routes/test_example_images_routes.py
- python -m pytest tests/services/test_use_cases.py *(fails: ModuleNotFoundError: No module named 'py_local')*


------
https://chatgpt.com/codex/tasks/task_e_68d22b8018d883208c5b0414a8440e8f