### PR TITLE
feat: add download example images to global context menu

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/en.json
+++ b/locales/en.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "Download example images",
+            "missingPath": "Set a download location before downloading example images.",
+            "unavailable": "Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/es.json
+++ b/locales/es.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -123,6 +123,11 @@
         }
     },
     "globalContextMenu": {
+        "downloadExampleImages": {
+            "label": "[TODO: Translate] Download example images",
+            "missingPath": "[TODO: Translate] Set a download location before downloading example images.",
+            "unavailable": "[TODO: Translate] Example image downloads aren't available yet. Try again after the page finishes loading."
+        },
         "cleanupExampleImages": {
             "label": "Clean up example image folders",
             "success": "Moved {count} folder(s) to the deleted folder",

--- a/static/js/components/ContextMenu/GlobalContextMenu.js
+++ b/static/js/components/ContextMenu/GlobalContextMenu.js
@@ -1,5 +1,6 @@
 import { BaseContextMenu } from './BaseContextMenu.js';
 import { showToast } from '../../utils/uiHelpers.js';
+import { state } from '../../state/index.js';
 
 export class GlobalContextMenu extends BaseContextMenu {
     constructor() {
@@ -19,9 +20,37 @@ export class GlobalContextMenu extends BaseContextMenu {
                     console.error('Failed to trigger example images cleanup:', error);
                 });
                 break;
+            case 'download-example-images':
+                this.downloadExampleImages(menuItem).catch((error) => {
+                    console.error('Failed to trigger example images download:', error);
+                });
+                break;
             default:
                 console.warn(`Unhandled global context menu action: ${action}`);
                 break;
+        }
+    }
+
+    async downloadExampleImages(menuItem) {
+        const exampleImagesManager = window.exampleImagesManager;
+
+        if (!exampleImagesManager) {
+            showToast('globalContextMenu.downloadExampleImages.unavailable', {}, 'error');
+            return;
+        }
+
+        const downloadPath = state?.global?.settings?.example_images_path;
+        if (!downloadPath) {
+            showToast('globalContextMenu.downloadExampleImages.missingPath', {}, 'warning');
+            return;
+        }
+
+        menuItem?.classList.add('disabled');
+
+        try {
+            await exampleImagesManager.handleDownloadButton();
+        } finally {
+            menuItem?.classList.remove('disabled');
         }
     }
 

--- a/templates/components/context_menu.html
+++ b/templates/components/context_menu.html
@@ -85,6 +85,9 @@
 </div>
 
 <div id="globalContextMenu" class="context-menu">
+    <div class="context-menu-item" data-action="download-example-images">
+        <i class="fas fa-download"></i> <span>{{ t('globalContextMenu.downloadExampleImages.label') }}</span>
+    </div>
     <div class="context-menu-item" data-action="cleanup-example-images-folders">
         <i class="fas fa-trash-restore"></i> <span>{{ t('globalContextMenu.cleanupExampleImages.label') }}</span>
     </div>


### PR DESCRIPTION
## Summary
- add a global context menu action that reuses the example image download workflow
- update the shared context menu template and translations for the new action and status messaging

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d295ceea288320abe2df421198348f