### PR TITLE
test: standardize backend package imports

### DIFF
--- a/tests/routes/test_base_model_routes_smoke.py
+++ b/tests/routes/test_base_model_routes_smoke.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib.util
 import json
 import os
 import sys
@@ -14,25 +13,13 @@ import pytest
 from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-PY_PACKAGE_PATH = REPO_ROOT / "py"
-
-spec = importlib.util.spec_from_file_location(
-    "py_local",
-    PY_PACKAGE_PATH / "__init__.py",
-    submodule_search_locations=[str(PY_PACKAGE_PATH)],
-)
-py_local = importlib.util.module_from_spec(spec)
-assert spec.loader is not None  # for mypy/static analyzers
-spec.loader.exec_module(py_local)
-sys.modules.setdefault("py_local", py_local)
-
-from py_local.routes.base_model_routes import BaseModelRoutes
-from py_local.services.model_file_service import AutoOrganizeResult
-from py_local.services.service_registry import ServiceRegistry
-from py_local.services.websocket_manager import ws_manager
-from py_local.utils.exif_utils import ExifUtils
-from py_local.config import config
+from py.config import config
+from py.routes.base_model_routes import BaseModelRoutes
+from py.services import model_file_service
+from py.services.model_file_service import AutoOrganizeResult
+from py.services.service_registry import ServiceRegistry
+from py.services.websocket_manager import ws_manager
+from py.utils.exif_utils import ExifUtils
 
 
 class DummyRoutes(BaseModelRoutes):
@@ -345,7 +332,7 @@ def test_auto_organize_route_emits_progress(mock_service, monkeypatch: pytest.Mo
         return result
 
     monkeypatch.setattr(
-        py_local.services.model_file_service.ModelFileService,
+        model_file_service.ModelFileService,
         "auto_organize_models",
         fake_auto_organize,
     )

--- a/tests/services/test_base_model_service.py
+++ b/tests/services/test_base_model_service.py
@@ -1,35 +1,13 @@
 import pytest
 
-import importlib
-import importlib.util
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-
-def import_from(module_name: str):
-    existing = sys.modules.get("py")
-    if existing is None or getattr(existing, "__file__", "") != str(ROOT / "py/__init__.py"):
-        sys.modules.pop("py", None)
-        spec = importlib.util.spec_from_file_location("py", ROOT / "py/__init__.py")
-        module = importlib.util.module_from_spec(spec)
-        assert spec and spec.loader
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
-        module.__path__ = [str(ROOT / "py")]
-        sys.modules["py"] = module
-    return importlib.import_module(module_name)
-
-
-BaseModelService = import_from("py.services.base_model_service").BaseModelService
-model_query_module = import_from("py.services.model_query")
-ModelCacheRepository = model_query_module.ModelCacheRepository
-ModelFilterSet = model_query_module.ModelFilterSet
-SearchStrategy = model_query_module.SearchStrategy
-SortParams = model_query_module.SortParams
-BaseModelMetadata = import_from("py.utils.models").BaseModelMetadata
+from py.services.base_model_service import BaseModelService
+from py.services.model_query import (
+    ModelCacheRepository,
+    ModelFilterSet,
+    SearchStrategy,
+    SortParams,
+)
+from py.utils.models import BaseModelMetadata
 
 
 class StubSettings:

--- a/tests/services/test_route_support_services.py
+++ b/tests/services/test_route_support_services.py
@@ -1,37 +1,15 @@
 import asyncio
 import json
 import os
-import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
-ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-import importlib
-import importlib.util
-
 import pytest
 
-
-def import_from(module_name: str):
-    existing = sys.modules.get("py")
-    if existing is None or getattr(existing, "__file__", "") != str(ROOT / "py/__init__.py"):
-        sys.modules.pop("py", None)
-        spec = importlib.util.spec_from_file_location("py", ROOT / "py/__init__.py")
-        module = importlib.util.module_from_spec(spec)
-        assert spec and spec.loader
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
-        module.__path__ = [str(ROOT / "py")]
-        sys.modules["py"] = module
-    return importlib.import_module(module_name)
-
-
-DownloadCoordinator = import_from("py.services.download_coordinator").DownloadCoordinator
-MetadataSyncService = import_from("py.services.metadata_sync_service").MetadataSyncService
-PreviewAssetService = import_from("py.services.preview_asset_service").PreviewAssetService
-TagUpdateService = import_from("py.services.tag_update_service").TagUpdateService
+from py.services.download_coordinator import DownloadCoordinator
+from py.services.metadata_sync_service import MetadataSyncService
+from py.services.preview_asset_service import PreviewAssetService
+from py.services.tag_update_service import TagUpdateService
 
 
 class DummySettings:

--- a/tests/services/test_use_cases.py
+++ b/tests/services/test_use_cases.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
-from py_local.services.model_file_service import AutoOrganizeResult
-from py_local.services.use_cases import (
+from py.services.model_file_service import AutoOrganizeResult
+from py.services.use_cases import (
     AutoOrganizeInProgressError,
     AutoOrganizeUseCase,
     BulkMetadataRefreshUseCase,
@@ -19,12 +19,12 @@ from py_local.services.use_cases import (
     ImportExampleImagesUseCase,
     ImportExampleImagesValidationError,
 )
-from py_local.utils.example_images_download_manager import (
+from py.utils.example_images_download_manager import (
     DownloadConfigurationError,
     DownloadInProgressError,
     ExampleImagesDownloadError,
 )
-from py_local.utils.example_images_processor import (
+from py.utils.example_images_processor import (
     ExampleImagesImportError,
     ExampleImagesValidationError,
 )


### PR DESCRIPTION
## Summary
- centralize repository package loading so backend tests import the real `py` package without custom loaders
- update route and service smoke tests to rely on standard module imports instead of bespoke `py_local` wiring
- clean up use case tests to reference canonical helpers after the alias removal

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4fc272fe08320937f491991836dca