### PR TITLE
Fix embedding relative paths by replacing spaces

### DIFF
--- a/py/services/download_manager.py
+++ b/py/services/download_manager.py
@@ -388,7 +388,10 @@ class DownloadManager:
         formatted_path = formatted_path.replace('{base_model}', mapped_base_model)
         formatted_path = formatted_path.replace('{first_tag}', first_tag)
         formatted_path = formatted_path.replace('{author}', author)
-        
+
+        if model_type == 'embedding':
+            formatted_path = formatted_path.replace(' ', '_')
+
         return formatted_path
 
     async def _execute_download(self, download_url: str, save_dir: str, 

--- a/py/utils/utils.py
+++ b/py/utils/utils.py
@@ -189,6 +189,9 @@ def calculate_relative_path_for_model(model_data: Dict, model_type: str = 'lora'
     formatted_path = formatted_path.replace('{first_tag}', first_tag)
     formatted_path = formatted_path.replace('{author}', author)
 
+    if model_type == 'embedding':
+        formatted_path = formatted_path.replace(' ', '_')
+
     return formatted_path
 
 def remove_empty_dirs(path):

--- a/tests/services/test_download_manager.py
+++ b/tests/services/test_download_manager.py
@@ -245,3 +245,17 @@ async def test_download_rejects_unsupported_model_type(monkeypatch, scanners):
 
     assert result["success"] is False
     assert result["error"].startswith("Model type")
+
+
+def test_embedding_relative_path_replaces_spaces():
+    manager = DownloadManager()
+
+    version_info = {
+        "baseModel": "Base Model",
+        "model": {"tags": ["tag with space"]},
+        "creator": {"username": "Author Name"},
+    }
+
+    relative_path = manager._calculate_relative_path(version_info, "embedding")
+
+    assert relative_path == "Base_Model/tag_with_space"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from py.services.settings_manager import settings
+from py.utils.utils import calculate_relative_path_for_model
+
+
+@pytest.fixture
+def isolated_settings(monkeypatch):
+    default_settings = settings._get_default_settings()
+    default_settings.update(
+        {
+            "download_path_templates": {
+                "lora": "{base_model}/{first_tag}",
+                "checkpoint": "{base_model}/{first_tag}",
+                "embedding": "{base_model}/{first_tag}",
+            },
+            "base_model_path_mappings": {},
+        }
+    )
+    monkeypatch.setattr(settings, "settings", default_settings)
+    monkeypatch.setattr(type(settings), "_save_settings", lambda self: None)
+    return default_settings
+
+
+def test_calculate_relative_path_for_embedding_replaces_spaces(isolated_settings):
+    model_data = {
+        "base_model": "Base Model",
+        "tags": ["tag with space"],
+        "civitai": {"id": 1, "creator": {"username": "Author Name"}},
+    }
+
+    relative_path = calculate_relative_path_for_model(model_data, "embedding")
+
+    assert relative_path == "Base_Model/tag_with_space"


### PR DESCRIPTION
## Summary
- sanitize embedding relative paths by replacing spaces with underscores in download handling and auto organize helpers
- add regression coverage for embedding relative path sanitization in download manager and utils

## Testing
- python -m pytest tests/services/test_download_manager.py tests/utils/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d5e4e833d8832096382f8a3075f81b