### PR TITLE
feat: add multi-library backend support

### DIFF
--- a/settings.json.example
+++ b/settings.json.example
@@ -1,5 +1,28 @@
 {
   "civitai_api_key": "your_civitai_api_key_here",
+  "active_library": "default",
+  "libraries": {
+    "default": {
+      "display_name": "Default Library",
+      "folder_paths": {
+        "loras": [
+          "C:/path/to/your/loras_folder",
+          "C:/path/to/another/loras_folder"
+        ],
+        "checkpoints": [
+          "C:/path/to/your/checkpoints_folder",
+          "C:/path/to/another/checkpoints_folder"
+        ],
+        "embeddings": [
+          "C:/path/to/your/embeddings_folder",
+          "C:/path/to/another/embeddings_folder"
+        ]
+      },
+      "default_lora_root": "C:/path/to/your/loras_folder",
+      "default_checkpoint_root": "C:/path/to/your/checkpoints_folder",
+      "default_embedding_root": "C:/path/to/your/embeddings_folder"
+    }
+  },
   "folder_paths": {
     "loras": [
       "C:/path/to/your/loras_folder",
@@ -13,5 +36,8 @@
       "C:/path/to/your/embeddings_folder",
       "C:/path/to/another/embeddings_folder"
     ]
-  }
+  },
+  "default_lora_root": "C:/path/to/your/loras_folder",
+  "default_checkpoint_root": "C:/path/to/your/checkpoints_folder",
+  "default_embedding_root": "C:/path/to/your/embeddings_folder"
 }

--- a/tests/services/test_model_scanner.py
+++ b/tests/services/test_model_scanner.py
@@ -312,7 +312,7 @@ async def test_update_single_model_cache_persists_changes(tmp_path: Path, monkey
     monkeypatch.setenv('LORA_MANAGER_DISABLE_PERSISTENT_CACHE', '0')
     db_path = tmp_path / 'cache.sqlite'
     monkeypatch.setenv('LORA_MANAGER_CACHE_DB', str(db_path))
-    monkeypatch.setattr(PersistentModelCache, '_instance', None, raising=False)
+    monkeypatch.setattr(PersistentModelCache, '_instances', {}, raising=False)
 
     _create_files(tmp_path)
     scanner = DummyScanner(tmp_path)
@@ -360,7 +360,7 @@ async def test_batch_delete_persists_removal(tmp_path: Path, monkeypatch):
     monkeypatch.setenv('LORA_MANAGER_DISABLE_PERSISTENT_CACHE', '0')
     db_path = tmp_path / 'cache.sqlite'
     monkeypatch.setenv('LORA_MANAGER_CACHE_DB', str(db_path))
-    monkeypatch.setattr(PersistentModelCache, '_instance', None, raising=False)
+    monkeypatch.setattr(PersistentModelCache, '_instances', {}, raising=False)
 
     first, _, _ = _create_files(tmp_path)
     scanner = DummyScanner(tmp_path)


### PR DESCRIPTION
## Summary
- manage a multi-library registry with activation helpers and service notifications
- update config path handling and persistent caches to align with the active library
- refresh default settings example and backend tests for multi-library awareness

## Testing
- pytest
- pytest tests/services/test_persistent_model_cache.py -q
- pytest tests/services/test_settings_manager.py -q
- pytest tests/services/test_model_scanner.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dfaf4689ec832090807cd841411e44