### PR TITLE
feat: serve dynamic preview assets after library switch

### DIFF
--- a/docs/library-switching.md
+++ b/docs/library-switching.md
@@ -1,0 +1,28 @@
+# Library Switching and Preview Routes
+
+Library switching no longer requires restarting the backend. The preview
+thumbnails shown in the UI are now served through a dynamic endpoint that
+resolves files against the folders registered for the active library at request
+time. This allows the multi-library flow to update model roots without touching
+the aiohttp router, so previews remain available immediately after a switch.
+
+## How the dynamic preview endpoint works
+
+* `config.get_preview_static_url()` now returns `/api/lm/previews?path=<encoded>`
+  for any preview path. The raw filesystem location is URL encoded so that it
+  can be passed through the query string without leaking directory structure in
+  the route itself.【F:py/config.py†L398-L404】
+* `PreviewRoutes` exposes the `/api/lm/previews` handler which validates the
+  decoded path against the directories registered for the current library. The
+  request is rejected if it falls outside those roots or if the file does not
+  exist.【F:py/routes/preview_routes.py†L5-L21】【F:py/routes/handlers/preview_handlers.py†L9-L48】
+* `Config` keeps an up-to-date cache of allowed preview roots. Every time a
+  library is applied the cache is rebuilt using the declared LoRA, checkpoint
+  and embedding directories (including symlink targets). The validation logic
+  checks preview requests against this cache.【F:py/config.py†L51-L68】【F:py/config.py†L180-L248】【F:py/config.py†L332-L346】
+
+Both the ComfyUI runtime (`LoraManager.add_routes`) and the standalone launcher
+(`StandaloneLoraManager.add_routes`) register the new preview routes instead of
+mounting a static directory per root. Switching libraries therefore works
+without restarting the application, and preview URLs generated before or after a
+switch continue to resolve correctly.【F:py/lora_manager.py†L21-L82】【F:standalone.py†L302-L315】

--- a/py/routes/handlers/preview_handlers.py
+++ b/py/routes/handlers/preview_handlers.py
@@ -1,0 +1,56 @@
+"""Handlers responsible for serving preview assets dynamically."""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+from pathlib import Path
+
+from aiohttp import web
+
+from ...config import config as global_config
+
+logger = logging.getLogger(__name__)
+
+
+class PreviewHandler:
+    """Serve preview assets for the active library at request time."""
+
+    def __init__(self, *, config=global_config) -> None:
+        self._config = config
+
+    async def serve_preview(self, request: web.Request) -> web.StreamResponse:
+        """Return the preview file referenced by the encoded ``path`` query."""
+
+        raw_path = request.query.get("path", "")
+        if not raw_path:
+            raise web.HTTPBadRequest(text="Missing 'path' query parameter")
+
+        try:
+            decoded_path = urllib.parse.unquote(raw_path)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.debug("Failed to decode preview path %s: %s", raw_path, exc)
+            raise web.HTTPBadRequest(text="Invalid preview path encoding") from exc
+
+        normalized = decoded_path.replace("\\", "/")
+        candidate = Path(normalized)
+        try:
+            resolved = candidate.expanduser().resolve(strict=False)
+        except Exception as exc:
+            logger.debug("Failed to resolve preview path %s: %s", normalized, exc)
+            raise web.HTTPBadRequest(text="Unable to resolve preview path") from exc
+
+        resolved_str = str(resolved)
+        if not self._config.is_preview_path_allowed(resolved_str):
+            logger.debug("Rejected preview outside allowed roots: %s", resolved_str)
+            raise web.HTTPForbidden(text="Preview path is not within an allowed directory")
+
+        if not resolved.is_file():
+            logger.debug("Preview file not found at %s", resolved_str)
+            raise web.HTTPNotFound(text="Preview file not found")
+
+        # aiohttp's FileResponse handles range requests and content headers for us.
+        return web.FileResponse(path=resolved, chunk_size=256 * 1024)
+
+
+__all__ = ["PreviewHandler"]

--- a/py/routes/preview_routes.py
+++ b/py/routes/preview_routes.py
@@ -1,0 +1,25 @@
+"""Route controller for preview asset delivery."""
+
+from __future__ import annotations
+
+from aiohttp import web
+
+from .handlers.preview_handlers import PreviewHandler
+
+
+class PreviewRoutes:
+    """Register routes that expose preview assets."""
+
+    def __init__(self, *, handler: PreviewHandler | None = None) -> None:
+        self._handler = handler or PreviewHandler()
+
+    @classmethod
+    def setup_routes(cls, app: web.Application) -> None:
+        controller = cls()
+        controller.register(app)
+
+    def register(self, app: web.Application) -> None:
+        app.router.add_get('/api/lm/previews', self._handler.serve_preview)
+
+
+__all__ = ["PreviewRoutes"]

--- a/tests/routes/test_preview_routes.py
+++ b/tests/routes/test_preview_routes.py
@@ -1,0 +1,112 @@
+import urllib.parse
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from py.config import Config
+from py.routes.handlers.preview_handlers import PreviewHandler
+
+
+async def test_preview_handler_serves_preview_from_active_library(tmp_path):
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    preview_file = library_root / "model.webp"
+    preview_file.write_bytes(b"preview")
+
+    config = Config()
+    config.apply_library_settings(
+        {
+            "folder_paths": {
+                "loras": [str(library_root)],
+                "checkpoints": [],
+                "unet": [],
+                "embeddings": [],
+            }
+        }
+    )
+
+    handler = PreviewHandler(config=config)
+    encoded_path = urllib.parse.quote(str(preview_file), safe="")
+    request = make_mocked_request("GET", f"/api/lm/previews?path={encoded_path}")
+
+    response = await handler.serve_preview(request)
+
+    assert isinstance(response, web.FileResponse)
+    assert response.status == 200
+    assert Path(response._path) == preview_file
+
+
+async def test_preview_handler_forbids_paths_outside_active_library(tmp_path):
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    forbidden_root = tmp_path / "forbidden"
+    forbidden_root.mkdir()
+    forbidden_file = forbidden_root / "sneaky.webp"
+    forbidden_file.write_bytes(b"x")
+
+    config = Config()
+    config.apply_library_settings(
+        {
+            "folder_paths": {
+                "loras": [str(allowed_root)],
+                "checkpoints": [],
+                "unet": [],
+                "embeddings": [],
+            }
+        }
+    )
+
+    handler = PreviewHandler(config=config)
+    encoded_path = urllib.parse.quote(str(forbidden_file), safe="")
+    request = make_mocked_request("GET", f"/api/lm/previews?path={encoded_path}")
+
+    with pytest.raises(web.HTTPForbidden):
+        await handler.serve_preview(request)
+
+
+async def test_config_updates_preview_roots_after_switch(tmp_path):
+    first_root = tmp_path / "first"
+    first_root.mkdir()
+    second_root = tmp_path / "second"
+    second_root.mkdir()
+
+    first_preview = first_root / "model.webp"
+    first_preview.write_bytes(b"a")
+    second_preview = second_root / "model.webp"
+    second_preview.write_bytes(b"b")
+
+    config = Config()
+    config.apply_library_settings(
+        {
+            "folder_paths": {
+                "loras": [str(first_root)],
+                "checkpoints": [],
+                "unet": [],
+                "embeddings": [],
+            }
+        }
+    )
+
+    assert config.is_preview_path_allowed(str(first_preview))
+    assert not config.is_preview_path_allowed(str(second_preview))
+
+    config.apply_library_settings(
+        {
+            "folder_paths": {
+                "loras": [str(second_root)],
+                "checkpoints": [],
+                "unet": [],
+                "embeddings": [],
+            }
+        }
+    )
+
+    assert config.is_preview_path_allowed(str(second_preview))
+    assert not config.is_preview_path_allowed(str(first_preview))
+
+    preview_url = config.get_preview_static_url(str(second_preview))
+    assert preview_url.startswith("/api/lm/previews?path=")
+    decoded = urllib.parse.unquote(preview_url.split("path=", 1)[1])
+    assert decoded.replace("\\", "/").endswith("model.webp")


### PR DESCRIPTION
## Summary
- replace static preview mounts with the new `/api/lm/previews` endpoint so library switches keep thumbnails online
- harden configuration to track allowed preview roots and validate requests dynamically across both ComfyUI and standalone boots
- document the new behaviour and add regression tests covering the handler and config updates

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e08167dc088320ab7255326e81ca45