### PR TITLE
fix: route recipe previews through preview API

### DIFF
--- a/py/routes/handlers/recipe_handlers.py
+++ b/py/routes/handlers/recipe_handlers.py
@@ -206,17 +206,15 @@ class RecipeListingHandler:
 
     def format_recipe_file_url(self, file_path: str) -> str:
         try:
-            recipes_dir = os.path.join(config.loras_roots[0], "recipes").replace(os.sep, "/")
-            normalized_path = file_path.replace(os.sep, "/")
-            if normalized_path.startswith(recipes_dir):
-                relative_path = os.path.relpath(file_path, config.loras_roots[0]).replace(os.sep, "/")
-                return f"/loras_static/root1/preview/{relative_path}"
-
-            file_name = os.path.basename(file_path)
-            return f"/loras_static/root1/preview/recipes/{file_name}"
+            normalized_path = os.path.normpath(file_path)
+            static_url = config.get_preview_static_url(normalized_path)
+            if static_url:
+                return static_url
         except Exception as exc:  # pragma: no cover - logging path
             self._logger.error("Error formatting recipe file URL: %s", exc, exc_info=True)
             return "/loras_static/images/no-preview.png"
+
+        return "/loras_static/images/no-preview.png"
 
 
 class RecipeQueryHandler:

--- a/py/services/recipe_scanner.py
+++ b/py/services/recipe_scanner.py
@@ -742,20 +742,17 @@ class RecipeScanner:
         """Format file path as URL for serving in web UI"""
         if not file_path:
             return '/loras_static/images/no-preview.png'
-            
+
         try:
-            # Format file path as a URL that will work with static file serving
-            recipes_dir = os.path.join(config.loras_roots[0], "recipes").replace(os.sep, '/')
-            if file_path.replace(os.sep, '/').startswith(recipes_dir):
-                relative_path = os.path.relpath(file_path, config.loras_roots[0]).replace(os.sep, '/')
-                return f"/loras_static/root1/preview/{relative_path}"
-                
-            # If not in recipes dir, try to create a valid URL from the file name
-            file_name = os.path.basename(file_path)
-            return f"/loras_static/root1/preview/recipes/{file_name}"
+            normalized_path = os.path.normpath(file_path)
+            static_url = config.get_preview_static_url(normalized_path)
+            if static_url:
+                return static_url
         except Exception as e:
             logger.error(f"Error formatting file URL: {e}")
             return '/loras_static/images/no-preview.png'
+
+        return '/loras_static/images/no-preview.png'
     
     def _format_timestamp(self, timestamp: float) -> str:
         """Format timestamp for display"""


### PR DESCRIPTION
## Summary
- update recipe scanner preview URL formatting to rely on config.get_preview_static_url
- reuse the preview URL helper in recipe route handler while keeping the placeholder fallback

## Testing
- not run (not requested)

## Manual Verification
- not run (requires UI access)


------
https://chatgpt.com/codex/tasks/task_e_68e22097245483208223fa139f519136