### PR TITLE
Fix tests for missing os.startfile on non-Windows

### DIFF
--- a/tests/utils/test_example_images_file_manager.py
+++ b/tests/utils/test_example_images_file_manager.py
@@ -48,7 +48,7 @@ async def test_open_folder_requires_existing_model_directory(monkeypatch: pytest
         startfile_calls.append(path)
 
     monkeypatch.setattr("subprocess.Popen", DummyPopen)
-    monkeypatch.setattr("os.startfile", dummy_startfile)
+    monkeypatch.setattr("os.startfile", dummy_startfile, raising=False)
 
     request = JsonRequest({"model_hash": model_hash})
     response = await ExampleImagesFileManager.open_folder(request)


### PR DESCRIPTION
## Summary
- allow the example images test suite to monkeypatch os.startfile even when the attribute does not exist

## Testing
- pytest tests/utils/test_example_images_file_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e22b733cd0832082abb670c4db12cd