### PR TITLE
feat(downloads): expose throughput metrics in progress APIs

### DIFF
--- a/py/routes/handlers/model_handlers.py
+++ b/py/routes/handlers/model_handlers.py
@@ -766,7 +766,15 @@ class ModelDownloadHandler:
             progress_data = self._ws_manager.get_download_progress(download_id)
             if progress_data is None:
                 return web.json_response({"success": False, "error": "Download ID not found"}, status=404)
-            return web.json_response({"success": True, "progress": progress_data.get("progress", 0)})
+            return web.json_response(
+                {
+                    "success": True,
+                    "progress": progress_data.get("progress", 0),
+                    "bytes_downloaded": progress_data.get("bytes_downloaded"),
+                    "total_bytes": progress_data.get("total_bytes"),
+                    "bytes_per_second": progress_data.get("bytes_per_second", 0.0),
+                }
+            )
         except Exception as exc:
             self._logger.error("Error getting download progress: %s", exc, exc_info=True)
             return web.json_response({"success": False, "error": str(exc)}, status=500)

--- a/py/services/metadata_archive_manager.py
+++ b/py/services/metadata_archive_manager.py
@@ -3,7 +3,7 @@ import logging
 import asyncio
 from pathlib import Path
 from typing import Optional
-from .downloader import get_downloader
+from .downloader import get_downloader, DownloadProgress
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +77,15 @@ class MetadataArchiveManager:
                     progress_callback("download", f"Downloading from {url}")
                 
                 # Custom progress callback to report download progress
-                async def download_progress(progress):
+                async def download_progress(progress, snapshot=None):
                     if progress_callback:
-                        progress_callback("download", f"Downloading archive... {progress:.1f}%")
+                        if isinstance(progress, DownloadProgress):
+                            percent = progress.percent_complete
+                        elif isinstance(snapshot, DownloadProgress):
+                            percent = snapshot.percent_complete
+                        else:
+                            percent = float(progress or 0)
+                        progress_callback("download", f"Downloading archive... {percent:.1f}%")
                 
                 success, result = await downloader.download_file(
                     url=url,

--- a/py/services/websocket_manager.py
+++ b/py/services/websocket_manager.py
@@ -155,11 +155,16 @@ class WebSocketManager:
 
     async def broadcast_download_progress(self, download_id: str, data: Dict):
         """Send progress update to specific download client"""
-        # Store simplified progress data in memory (only progress percentage)
-        self._download_progress[download_id] = {
+        progress_entry = {
             'progress': data.get('progress', 0),
-            'timestamp': datetime.now()
+            'timestamp': datetime.now(),
         }
+
+        for field in ('bytes_downloaded', 'total_bytes', 'bytes_per_second'):
+            if field in data:
+                progress_entry[field] = data[field]
+
+        self._download_progress[download_id] = progress_entry
         
         if download_id not in self._download_websockets:
             logger.debug(f"No WebSocket found for download ID: {download_id}")


### PR DESCRIPTION
## Summary
- add a `DownloadProgress` snapshot to capture throughput details and update downloader callbacks to compute moving-average speeds
- persist byte counts and current speed in the download manager while surfacing them through websocket and REST progress payloads
- adjust supporting handlers and tests, including metadata archive progress reporting, to consume the richer progress data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec66d14f5c8320b80d4fff427b7432