### PR TITLE
feat(move): preserve folder structure with {original_path}

### DIFF
--- a/py/services/model_file_service.py
+++ b/py/services/model_file_service.py
@@ -429,7 +429,9 @@ class ModelFileService:
             return current_root
         else:
             # Calculate new relative path based on settings
-            new_relative_path = calculate_relative_path_for_model(model, self.model_type)
+            new_relative_path = calculate_relative_path_for_model(
+                model, self.model_type, self.get_model_roots()
+            )
             
             if not new_relative_path:
                 return None  # Signal to skip
@@ -506,7 +508,9 @@ class ModelMoveService:
                 
                 if model_data:
                     from ..utils.utils import calculate_relative_path_for_model
-                    relative_path = calculate_relative_path_for_model(model_data, self.model_type)
+                    relative_path = calculate_relative_path_for_model(
+                        model_data, self.model_type, self.scanner.get_model_roots()
+                    )
                     if relative_path:
                         target_path = os.path.join(target_path, relative_path).replace(os.sep, '/')
                     elif not get_settings_manager().get_download_path_template(self.model_type):

--- a/py/utils/utils.py
+++ b/py/utils/utils.py
@@ -524,13 +524,16 @@ def normalize_prompt_for_dedup(prompt) -> str:
 
 
 def calculate_relative_path_for_model(
-    model_data: Dict[str, Any], model_type: str = "lora"
+    model_data: Dict[str, Any],
+    model_type: str = "lora",
+    model_roots: Optional[List[str]] = None,
 ) -> str:
     """Calculate relative path for existing model using template from settings
 
     Args:
         model_data: Model data from scanner cache
         model_type: Type of model ('lora', 'checkpoint', 'embedding')
+        model_roots: Roots used to resolve the model's current relative folder
 
     Returns:
         Relative path string (empty string for flat structure)
@@ -579,7 +582,35 @@ def calculate_relative_path_for_model(
     if isinstance(civitai_data, dict):
         version_name = sanitize_folder_name(civitai_data.get("name") or "")
 
+    original_path = ""
+    if "{original_path}" in path_template:
+        file_path = model_data.get("file_path")
+        if isinstance(file_path, str) and file_path and model_roots:
+            absolute_file = os.path.abspath(file_path)
+            matching_roots = []
+            for root in model_roots:
+                if not isinstance(root, str) or not root:
+                    continue
+                absolute_root = os.path.abspath(root)
+                try:
+                    common_path = os.path.commonpath([absolute_file, absolute_root])
+                    if os.path.normcase(common_path) == os.path.normcase(absolute_root):
+                        matching_roots.append(absolute_root)
+                except ValueError:
+                    # Different Windows drives cannot share a common path.
+                    continue
+
+            if matching_roots:
+                # Prefer the most specific root when configured roots overlap.
+                current_root = max(matching_roots, key=len)
+                relative_dir = os.path.relpath(
+                    os.path.dirname(absolute_file), current_root
+                )
+                if relative_dir != ".":
+                    original_path = relative_dir.replace(os.sep, "/")
+
     formatted_path = path_template
+    formatted_path = formatted_path.replace("{original_path}", original_path)
     formatted_path = formatted_path.replace("{base_model}", mapped_base_model)
     formatted_path = formatted_path.replace("{first_tag}", first_tag)
     formatted_path = formatted_path.replace("{author}", author)

--- a/static/js/managers/SettingsManager.js
+++ b/static/js/managers/SettingsManager.js
@@ -2203,7 +2203,8 @@ export class SettingsManager {
             const exampleTemplate = template
                 .replace('{base_model}', 'Flux.1 D')
                 .replace('{author}', 'authorname')
-                .replace('{first_tag}', 'style');
+                .replace('{first_tag}', 'style')
+                .replace('{original_path}', 'characters/favorites');
             previewElement.textContent = `${exampleTemplate}/model-name.safetensors`;
         }
         previewElement.style.display = 'block';

--- a/static/js/utils/constants.js
+++ b/static/js/utils/constants.js
@@ -334,7 +334,8 @@ export const PATH_TEMPLATE_PLACEHOLDERS = [
     '{author}',
     '{first_tag}',
     '{model_name}',
-    '{version_name}'
+    '{version_name}',
+    '{original_path}'
 ];
 
 // Default templates for each model type

--- a/templates/components/modals/settings/library.html
+++ b/templates/components/modals/settings/library.html
@@ -146,6 +146,7 @@
                     <span class="placeholder-tag">{first_tag}</span>
                     <span class="placeholder-tag">{model_name}</span>
                     <span class="placeholder-tag">{version_name}</span>
+                    <span class="placeholder-tag">{original_path}</span>
                 </div>
             </div>
         </div>

--- a/tests/services/test_model_file_service_original_path.py
+++ b/tests/services/test_model_file_service_original_path.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import pytest
+
+from py.services.model_file_service import ModelFileService, ModelMoveService
+from py.services.settings_manager import SettingsManager, get_settings_manager
+
+
+class _Scanner:
+    def __init__(self, roots, models):
+        self._roots = [str(root) for root in roots]
+        self._cache = SimpleNamespace(raw_data=models)
+        self.target_path = None
+
+    def get_model_roots(self):
+        return self._roots
+
+    async def get_cached_data(self):
+        return self._cache
+
+    async def move_model(self, source_path, target_path):
+        self.target_path = target_path
+        return {
+            "new_path": f"{target_path}/model.safetensors",
+            "cache_entry": {},
+        }
+
+
+@pytest.fixture
+def original_path_settings(monkeypatch):
+    manager = get_settings_manager()
+    settings = manager._get_default_settings()
+    settings["download_path_templates"]["lora"] = (
+        "{base_model}/{original_path}"
+    )
+    monkeypatch.setattr(manager, "settings", settings)
+    monkeypatch.setattr(SettingsManager, "_save_settings", lambda self: None)
+
+
+@pytest.mark.asyncio
+async def test_auto_organize_preserves_folder_below_source_root(
+    original_path_settings, tmp_path
+):
+    source_root = tmp_path / "source"
+    model = {
+        "file_path": str(
+            source_root / "People" / "Portraits" / "model.safetensors"
+        ),
+        "base_model": "SDXL",
+        "tags": [],
+    }
+    scanner = _Scanner([source_root], [model])
+    service = ModelFileService(scanner, "lora")
+
+    target = await service._calculate_target_directory(
+        model, str(source_root), is_flat_structure=False
+    )
+
+    assert target.replace("\\", "/").endswith("source/SDXL/People/Portraits")
+
+
+@pytest.mark.asyncio
+async def test_default_path_move_preserves_folder_across_roots(
+    original_path_settings, tmp_path
+):
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "archive"
+    source_path = str(
+        source_root / "People" / "Portraits" / "model.safetensors"
+    )
+    model = {
+        "file_path": source_path,
+        "base_model": "SDXL",
+        "tags": [],
+    }
+    scanner = _Scanner([source_root, target_root], [model])
+    service = ModelMoveService(scanner, "lora")
+
+    result = await service.move_model(
+        source_path, str(target_root), use_default_paths=True
+    )
+
+    assert result["success"] is True
+    assert scanner.target_path.replace("\\", "/").endswith(
+        "archive/SDXL/People/Portraits"
+    )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -146,6 +146,71 @@ def test_calculate_relative_path_sanitizes_double_slashes(isolated_settings):
     assert relative_path == "no tags/Author"
 
 
+def test_calculate_relative_path_preserves_original_folder(isolated_settings, tmp_path):
+    isolated_settings["download_path_templates"]["lora"] = (
+        "{base_model}/{original_path}"
+    )
+    root = tmp_path / "loras"
+    model_data = {
+        "file_path": str(root / "People" / "Portraits" / "model.safetensors"),
+        "base_model": "SDXL",
+        "tags": [],
+    }
+
+    relative_path = calculate_relative_path_for_model(
+        model_data, "lora", [str(root)]
+    )
+
+    assert relative_path == "SDXL/People/Portraits"
+
+
+def test_calculate_relative_path_uses_most_specific_root(isolated_settings, tmp_path):
+    isolated_settings["download_path_templates"]["lora"] = "{original_path}"
+    root = tmp_path / "models"
+    nested_root = root / "loras"
+    model_data = {
+        "file_path": str(nested_root / "Styles" / "model.safetensors"),
+        "tags": [],
+    }
+
+    relative_path = calculate_relative_path_for_model(
+        model_data, "lora", [str(root), str(nested_root)]
+    )
+
+    assert relative_path == "Styles"
+
+
+def test_calculate_relative_path_at_root_is_empty(isolated_settings, tmp_path):
+    isolated_settings["download_path_templates"]["lora"] = "{original_path}"
+    root = tmp_path / "loras"
+    model_data = {
+        "file_path": str(root / "model.safetensors"),
+        "tags": [],
+    }
+
+    relative_path = calculate_relative_path_for_model(
+        model_data, "lora", [str(root)]
+    )
+
+    assert relative_path == ""
+
+
+def test_calculate_relative_path_ignores_unrelated_roots(isolated_settings, tmp_path):
+    isolated_settings["download_path_templates"]["lora"] = (
+        "archive/{original_path}"
+    )
+    model_data = {
+        "file_path": str(tmp_path / "outside" / "model.safetensors"),
+        "tags": [],
+    }
+
+    relative_path = calculate_relative_path_for_model(
+        model_data, "lora", [str(tmp_path / "loras")]
+    )
+
+    assert relative_path == "archive"
+
+
 def test_calculate_recipe_fingerprint_filters_and_sorts():
     loras = [
         {"hash": "ABC", "strength": 0.1234},


### PR DESCRIPTION
## Problem

Bulk-moving a filtered subset of models to another configured root flattens their existing folder organization. For example, moving only SDXL LoRAs from a mixed library should be able to preserve `People/Portraits` and `Styles/Anime` below the destination root.

## Result

Adds `{original_path}` to download path templates. With the template `{base_model}/{original_path}`, a model at:

```text
C:/Models/LoRA/People/Portraits/model.safetensors
```

moved to `D:/Archive/LoRA` becomes:

```text
D:/Archive/LoRA/SDXL/People/Portraits/model.safetensors
```

The placeholder works with both Auto-organize and the Move dialog's existing **Use default paths** option. It resolves the folder relative to the most specific configured source root, handles overlapping roots, and stays empty for models already at a root or outside the supplied roots.

## Current architecture

This branch is rebuilt from current `main`. It uses the existing `use_default_paths` move flow and shared path-template resolver, so no move-specific template API or duplicate UI is required.

The old fixed 260-character path validation was removed from this PR because Windows path limits depend on system and application long-path support and are separate from folder preservation.

## Validation

- `pytest -q tests/utils/test_utils.py tests/utils/test_utils_case_sensitivity.py tests/services/test_model_file_service_original_path.py` — 30 passed
- `npm run test:js` — 1,023 passed
- Full backend run — 2,537 passed; unrelated existing Windows/symlink, shared-settings, and SQLite cleanup failures remain
