### PR TITLE
fix: sanitize path template folder names

### DIFF
--- a/py/services/download_manager.py
+++ b/py/services/download_manager.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from ..utils.models import LoraMetadata, CheckpointMetadata, EmbeddingMetadata
 from ..utils.constants import CARD_PREVIEW_WIDTH, VALID_LORA_TYPES
 from ..utils.civitai_utils import rewrite_preview_url
+from ..utils.utils import sanitize_folder_name
 from ..utils.exif_utils import ExifUtils
 from ..utils.metadata_manager import MetadataManager
 from .service_registry import ServiceRegistry
@@ -427,8 +428,8 @@ class DownloadManager:
         formatted_path = formatted_path.replace('{base_model}', mapped_base_model)
         formatted_path = formatted_path.replace('{first_tag}', first_tag)
         formatted_path = formatted_path.replace('{author}', author)
-        formatted_path = formatted_path.replace('{model_name}', model_info.get('name', ''))
-        formatted_path = formatted_path.replace('{version_name}', version_info.get('name', ''))
+        formatted_path = formatted_path.replace('{model_name}', sanitize_folder_name(model_info.get('name', '')))
+        formatted_path = formatted_path.replace('{version_name}', sanitize_folder_name(version_info.get('name', '')))
 
         if model_type == 'embedding':
             formatted_path = formatted_path.replace(' ', '_')

--- a/tests/services/test_download_manager.py
+++ b/tests/services/test_download_manager.py
@@ -340,6 +340,22 @@ def test_relative_path_supports_model_and_version_placeholders():
     assert relative_path == "Fancy Model/Version One"
 
 
+def test_relative_path_sanitizes_model_and_version_placeholders():
+    manager = DownloadManager()
+    settings_manager = get_settings_manager()
+    settings_manager.settings["download_path_templates"]["lora"] = "{model_name}/{version_name}"
+
+    version_info = {
+        "baseModel": "BaseModel",
+        "name": "Version:One?",
+        "model": {"name": "Fancy:Model*", "tags": []},
+    }
+
+    relative_path = manager._calculate_relative_path(version_info, "lora")
+
+    assert relative_path == "Fancy_Model/Version_One"
+
+
 async def test_execute_download_retries_urls(monkeypatch, tmp_path):
     manager = DownloadManager()
 


### PR DESCRIPTION
## Summary
- add a `sanitize_folder_name` utility to normalize invalid filesystem characters
- apply sanitization to model and version placeholders when building path templates
- add regression tests for sanitized relative paths and the utility helper

## Testing
- python -m pytest tests/utils/test_utils.py tests/services/test_download_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68f34b1d99c48320a8d70e8dc5e9fc5a