### PR TITLE
fix: disable compression in default downloader headers

### DIFF
--- a/py/services/downloader.py
+++ b/py/services/downloader.py
@@ -70,7 +70,10 @@ class Downloader:
         
         # Default headers
         self.default_headers = {
-            'User-Agent': 'ComfyUI-LoRA-Manager/1.0'
+            'User-Agent': 'ComfyUI-LoRA-Manager/1.0',
+            # Explicitly request uncompressed payloads so aiohttp doesn't need optional
+            # decoders (e.g. zstandard) that may be missing in runtime environments.
+            'Accept-Encoding': 'identity',
         }
     
     @property


### PR DESCRIPTION
## Summary
- request identity encoding in the downloader's default headers so every code path opts out of server compression and avoids missing zstd decoders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f829b1521883208f1383a1cc394b64