### PR TITLE
fix: apply adjust_cached_entry during model reconciliation

### DIFF
--- a/py/services/model_scanner.py
+++ b/py/services/model_scanner.py
@@ -678,6 +678,9 @@ class ModelScanner:
                             if root_path:
                                 model_data = await self._process_model_file(path, root_path)
                                 if model_data:
+                                    model_data = self.adjust_cached_entry(dict(model_data))
+                                    if not model_data:
+                                        continue
                                     # Add to cache
                                     self._cache.raw_data.append(model_data)
                                     self._cache.add_to_version_index(model_data)


### PR DESCRIPTION
## Summary
- ensure new models discovered during cache reconciliation pass through the scanner's adjust_cached_entry hook
- cover the reconciliation behavior with a regression test that verifies model_type adjustments are applied

## Testing
- python -m pytest tests/services/test_model_scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68f8f86d01288320a0f922723733475d