### PR TITLE
feat(preview): respect blur mature content setting

### DIFF
--- a/py/utils/preview_selection.py
+++ b/py/utils/preview_selection.py
@@ -1,0 +1,63 @@
+"""Utilities for selecting preview media from Civitai image metadata."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Sequence, Tuple
+
+from .constants import NSFW_LEVELS
+
+PreviewMedia = Mapping[str, object]
+
+
+def _extract_nsfw_level(entry: Mapping[str, object]) -> int:
+    """Return a normalized NSFW level value for the supplied media entry."""
+
+    value = entry.get("nsfwLevel", 0)
+    try:
+        return int(value)  # type: ignore[return-value]
+    except (TypeError, ValueError):
+        return 0
+
+
+def select_preview_media(
+    images: Sequence[Mapping[str, object]] | None,
+    *,
+    blur_mature_content: bool,
+) -> Tuple[Optional[PreviewMedia], int]:
+    """Select the most appropriate preview media entry.
+
+    When ``blur_mature_content`` is enabled we first try to return the first media
+    item with an ``nsfwLevel`` lower than :pydata:`NSFW_LEVELS["R"]`. If none are
+    available we return the media entry with the lowest NSFW level. When the
+    setting is disabled we simply return the first entry.
+    """
+
+    if not images:
+        return None, 0
+
+    candidates = [item for item in images if isinstance(item, Mapping)]
+    if not candidates:
+        return None, 0
+
+    selected = candidates[0]
+    selected_level = _extract_nsfw_level(selected)
+
+    if not blur_mature_content:
+        return selected, selected_level
+
+    safe_threshold = NSFW_LEVELS.get("R", 4)
+    for candidate in candidates:
+        level = _extract_nsfw_level(candidate)
+        if level < safe_threshold:
+            return candidate, level
+
+    for candidate in candidates[1:]:
+        level = _extract_nsfw_level(candidate)
+        if level < selected_level:
+            selected = candidate
+            selected_level = level
+
+    return selected, selected_level
+
+
+__all__ = ["select_preview_media"]

--- a/tests/services/test_preview_asset_service.py
+++ b/tests/services/test_preview_asset_service.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from py.services import preview_asset_service
 from py.services.preview_asset_service import PreviewAssetService
 
 
@@ -180,3 +181,68 @@ async def test_ensure_preview_rewrites_civitai_video(tmp_path):
     assert preview_path.exists()
     assert preview_path.suffix == ".mp4"
     assert local_metadata["preview_nsfw_level"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_preview_respects_blur_setting(monkeypatch, tmp_path):
+    metadata_path = tmp_path / "model.metadata.json"
+    metadata_path.write_text("{}")
+    local_metadata: dict[str, Any] = {}
+
+    class Downloader:
+        def __init__(self):
+            self.file_calls: list[tuple[str, str]] = []
+
+        async def download_file(self, url, path, use_auth=False):
+            self.file_calls.append((url, path))
+            Path(path).write_bytes(b"image-data")
+            return True, None
+
+        async def download_to_memory(self, *_args, **_kwargs):
+            pytest.fail("download_to_memory should not be used when download_file succeeds")
+
+    downloader = Downloader()
+
+    async def downloader_factory():
+        return downloader
+
+    class StubSettingsManager:
+        def __init__(self, blur: bool) -> None:
+            self.blur = blur
+
+        def get(self, key: str, default=None):
+            if key == "blur_mature_content":
+                return self.blur
+            return default
+
+    monkeypatch.setattr(
+        preview_asset_service,
+        "get_settings_manager",
+        lambda: StubSettingsManager(True),
+    )
+
+    service = PreviewAssetService(
+        metadata_manager=StubMetadataManager(),
+        downloader_factory=downloader_factory,
+        exif_utils=RecordingExifUtils(),
+    )
+
+    images = [
+        {
+            "url": "https://image.civitai.com/container/example/original=true/nsfw.jpeg",
+            "type": "image",
+            "nsfwLevel": 8,
+        },
+        {
+            "url": "https://image.civitai.com/container/example/original=true/safe.jpeg",
+            "type": "image",
+            "nsfwLevel": 1,
+        },
+    ]
+
+    await service.ensure_preview_for_metadata(str(metadata_path), local_metadata, images)
+
+    assert len(downloader.file_calls) == 1
+    requested_url = downloader.file_calls[0][0]
+    assert "safe.jpeg" in requested_url
+    assert local_metadata["preview_nsfw_level"] == 1

--- a/tests/utils/test_preview_selection.py
+++ b/tests/utils/test_preview_selection.py
@@ -1,0 +1,39 @@
+from py.utils.preview_selection import select_preview_media
+
+
+def test_select_preview_prefers_safe_media_when_blurred():
+    images = [
+        {"url": "nsfw", "type": "image", "nsfwLevel": 8},
+        {"url": "mid", "type": "image", "nsfwLevel": 4},
+        {"url": "safe", "type": "image", "nsfwLevel": 1},
+    ]
+
+    selected, level = select_preview_media(images, blur_mature_content=True)
+
+    assert selected["url"] == "safe"
+    assert level == 1
+
+
+def test_select_preview_returns_lowest_when_no_safe_media():
+    images = [
+        {"url": "x", "type": "image", "nsfwLevel": 16},
+        {"url": "r", "type": "image", "nsfwLevel": 4},
+        {"url": "xx", "type": "image", "nsfwLevel": 8},
+    ]
+
+    selected, level = select_preview_media(images, blur_mature_content=True)
+
+    assert selected["url"] == "r"
+    assert level == 4
+
+
+def test_select_preview_returns_first_when_blur_disabled():
+    images = [
+        {"url": "nsfw", "type": "image", "nsfwLevel": 32},
+        {"url": "safe", "type": "image", "nsfwLevel": 1},
+    ]
+
+    selected, level = select_preview_media(images, blur_mature_content=False)
+
+    assert selected["url"] == "nsfw"
+    assert level == 32


### PR DESCRIPTION
## Summary
- add a shared selector for preview media that honours the blur_mature_content preference
- update download and preview asset flows to choose the first safe media or the least mature fallback
- cover the new behaviour with service-level assertions and targeted selector unit tests

## Testing
- pytest tests/services/test_preview_asset_service.py tests/services/test_download_manager.py tests/utils/test_preview_selection.py

------
https://chatgpt.com/codex/tasks/task_e_68fbfed215c8832099d59adf30af1a33