### PR TITLE
fix: keep config in sync with library folder paths

### DIFF
--- a/py/services/settings_manager.py
+++ b/py/services/settings_manager.py
@@ -153,6 +153,7 @@ class SettingsManager:
             self.settings["active_library"] = library_name
             self._sync_active_library_to_root(save=False)
             self._save_settings()
+            self._notify_library_change(library_name)
             return
 
         sanitized_libraries: Dict[str, Dict[str, Any]] = {}
@@ -183,6 +184,10 @@ class SettingsManager:
                 self.settings["active_library"] = "default"
 
         self._sync_active_library_to_root(save=changed)
+
+        active_library = self.settings.get("active_library")
+        if active_library and active_library in self.settings.get("libraries", {}):
+            self._notify_library_change(active_library)
 
     def _sync_active_library_to_root(self, *, save: bool = False) -> None:
         """Update top-level folder path settings to mirror the active library."""


### PR DESCRIPTION
## Summary
- teach the standalone mock folder path resolver to fall back to the active library entry when the top-level map is empty
- notify the global config after migrating settings into the library registry so new folder paths take effect immediately

## Testing
- python standalone.py --port 8188


------
https://chatgpt.com/codex/tasks/task_e_68fe06bd76048320b04415c5d6abbd28