### PR TITLE
Reduce core settings persistence to essential keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Enhance your Civitai browsing experience with our companion browser extension! S
 ### Option 2: **Portable Standalone Edition** (No ComfyUI required)
 
 1. Download the [Portable Package](https://github.com/willmiao/ComfyUI-Lora-Manager/releases/download/v0.9.8/lora_manager_portable.7z)
-2. Copy the provided `settings.json.example` file to create a new file named `settings.json` in `comfyui-lora-manager` folder
-3. Edit the new `settings.json` to include your correct model folder paths and CivitAI API key
+2. Copy the provided `settings.json.example` file to create a new file named `settings.json` in `comfyui-lora-manager` folder. Only adjust the API key, optional language, and folder paths—the library registry is generated automatically at runtime.
+3. Edit the new `settings.json` to include your correct model folder paths and CivitAI API key (or keep the placeholders until you are ready to configure them)
 4. Run run.bat
     - To change the startup port, edit `run.bat` and modify the parameter (e.g. `--port 9001`)
 
@@ -231,8 +231,8 @@ You can now run LoRA Manager independently from ComfyUI:
      ```
 
 2. **For non-ComfyUI users**:
-   - Copy the provided `settings.json.example` file to create a new file named `settings.json`
-   - Edit `settings.json` to include your correct model folder paths and CivitAI API key
+   - Copy the provided `settings.json.example` file to create a new file named `settings.json`. Update the API key, optional language, and folder paths only—the library registry is created automatically when LoRA Manager starts.
+   - Edit `settings.json` to include your correct model folder paths and CivitAI API key (you can leave the defaults until ready to configure them)
    - Install required dependencies: `pip install -r requirements.txt`
    - Run standalone mode:
      ```bash

--- a/settings.json.example
+++ b/settings.json.example
@@ -1,17 +1,16 @@
 {
+  "_note": "LoRA Manager builds the detailed library registry automatically at runtime.",
+  "language": "en",
   "civitai_api_key": "your_civitai_api_key_here",
   "folder_paths": {
     "loras": [
-      "C:/path/to/your/loras_folder",
-      "C:/path/to/another/loras_folder"
+      "C:/path/to/your/loras_folder"
     ],
     "checkpoints": [
-      "C:/path/to/your/checkpoints_folder",
-      "C:/path/to/another/checkpoints_folder"
+      "C:/path/to/your/checkpoints_folder"
     ],
     "embeddings": [
-      "C:/path/to/your/embeddings_folder",
-      "C:/path/to/another/embeddings_folder"
+      "C:/path/to/your/embeddings_folder"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- update the settings manager so minimal persistence only covers the API key and folder paths

## Testing
- python -m pytest tests/services/test_settings_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68fe06bb4114832080fbf37204a94d21