### PR TITLE
fix: allow legacy library folders when validating example image paths

### DIFF
--- a/py/utils/example_images_paths.py
+++ b/py/utils/example_images_paths.py
@@ -199,10 +199,13 @@ def is_valid_example_images_root(folder_path: str) -> bool:
             if item == "_deleted":
                 # Allow cleanup staging folders
                 continue
-            # When multi-library mode is active we expect nested hash folders
-            if uses_library_scoped_folders():
-                if _library_folder_has_only_hash_dirs(item_path):
-                    continue
+            # Accept legacy library folders even when current settings do not
+            # explicitly enable multi-library mode. This allows users to reuse a
+            # previously configured example images directory after settings are
+            # reset, as long as the nested structure still looks like dedicated
+            # hash folders.
+            if _library_folder_has_only_hash_dirs(item_path):
+                continue
         return False
 
     return True

--- a/tests/utils/test_example_images_paths.py
+++ b/tests/utils/test_example_images_paths.py
@@ -125,3 +125,18 @@ def test_is_valid_example_images_root_accepts_hash_directories(tmp_path, setting
     # Add a non-hash file to make it clearly invalid
     (invalid_folder / 'invalid.txt').write_text('invalid', encoding='utf-8')
     assert is_valid_example_images_root(str(tmp_path)) is False
+
+
+def test_is_valid_example_images_root_accepts_legacy_library_structure(tmp_path, settings_manager):
+    settings_manager.settings['example_images_path'] = str(tmp_path)
+    # Simulate settings reset where libraries configuration is missing
+    settings_manager.settings['libraries'] = {'default': {}}
+    settings_manager.settings['active_library'] = 'default'
+
+    legacy_library = tmp_path / 'My Library'
+    legacy_library.mkdir()
+    hash_folder = legacy_library / ('e' * 64)
+    hash_folder.mkdir()
+    (hash_folder / 'image.png').write_text('data', encoding='utf-8')
+
+    assert is_valid_example_images_root(str(tmp_path)) is True


### PR DESCRIPTION
## Summary
- allow the example images path validator to accept legacy library folders even when multi-library mode is not currently configured
- add a regression test that verifies legacy library structures are accepted

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ff32e0093483208c1586f52c844f8d