### PR TITLE
fix: ignore removed civitai models during update refresh

### DIFF
--- a/py/routes/handlers/misc_handlers.py
+++ b/py/routes/handlers/misc_handlers.py
@@ -27,6 +27,7 @@ from ...services.service_registry import ServiceRegistry
 from ...services.settings_manager import get_settings_manager
 from ...services.websocket_manager import ws_manager
 from ...services.downloader import get_downloader
+from ...services.errors import ResourceNotFoundError
 from ...utils.constants import (
     CIVITAI_USER_MODEL_TYPES,
     DEFAULT_NODE_COLOR,
@@ -618,7 +619,10 @@ class ModelLibraryHandler:
             if not metadata_provider:
                 return web.json_response({"success": False, "error": "Metadata provider not available"}, status=503)
 
-            response = await metadata_provider.get_model_versions(model_id)
+            try:
+                response = await metadata_provider.get_model_versions(model_id)
+            except ResourceNotFoundError:
+                return web.json_response({"success": False, "error": "Model not found"}, status=404)
             if not response or not response.get("modelVersions"):
                 return web.json_response({"success": False, "error": "Model not found"}, status=404)
 

--- a/py/routes/handlers/model_handlers.py
+++ b/py/routes/handlers/model_handlers.py
@@ -29,7 +29,7 @@ from ...services.use_cases import (
 )
 from ...services.websocket_manager import WebSocketManager
 from ...services.websocket_progress_callback import WebSocketProgressCallback
-from ...services.errors import RateLimitError
+from ...services.errors import RateLimitError, ResourceNotFoundError
 from ...utils.file_utils import calculate_sha256
 from ...utils.metadata_manager import MetadataManager
 
@@ -863,7 +863,10 @@ class ModelCivitaiHandler:
         try:
             model_id = request.match_info["model_id"]
             metadata_provider = await self._metadata_provider_factory()
-            response = await metadata_provider.get_model_versions(model_id)
+            try:
+                response = await metadata_provider.get_model_versions(model_id)
+            except ResourceNotFoundError:
+                return web.Response(status=404, text="Model not found")
             if not response or not response.get("modelVersions"):
                 return web.Response(status=404, text="Model not found")
 

--- a/py/services/errors.py
+++ b/py/services/errors.py
@@ -19,3 +19,9 @@ class RateLimitError(RuntimeError):
         self.retry_after = retry_after
         self.provider = provider
 
+
+class ResourceNotFoundError(RuntimeError):
+    """Raised when a remote resource is permanently missing."""
+
+    pass
+


### PR DESCRIPTION
## Summary
- raise a dedicated error when the Civitai API reports that a model no longer exists
- mark missing models as ignored during the update refresh workflow and log the decision
- propagate not-found responses through HTTP handlers and cover the behavior with service tests
- ensure the Civitai client surfaces not-found errors so the ignore logic can run and add client-level coverage
- treat nested Civitai error payloads as not found, raise explicit runtime errors for other failures, and downgrade single-lookup logs to INFO with tests

## Testing
- python -m pytest tests/services/test_civitai_client.py tests/services/test_model_update_service.py

------
https://chatgpt.com/codex/tasks/task_e_6900971ee4ec8320bad0616abbaa4c0c