### PR TITLE
Fix portable settings to use project root storage

### DIFF
--- a/py/services/persistent_model_cache.py
+++ b/py/services/persistent_model_cache.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
 
-from ..utils.settings_paths import get_settings_dir
+from ..utils.settings_paths import get_project_root, get_settings_dir
 
 logger = logging.getLogger(__name__)
 
@@ -397,7 +397,7 @@ class PersistentModelCache:
             settings_dir = get_settings_dir(create=True)
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning("Falling back to project directory for cache: %s", exc)
-            settings_dir = os.path.dirname(os.path.dirname(self._db_path)) if hasattr(self, "_db_path") else os.getcwd()
+            settings_dir = get_project_root()
         safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", library_name or "default")
         if safe_name.lower() in ("default", ""):
             legacy_path = os.path.join(settings_dir, self._DEFAULT_FILENAME)

--- a/py/utils/settings_paths.py
+++ b/py/utils/settings_paths.py
@@ -37,8 +37,13 @@ def get_settings_dir(create: bool = True) -> str:
         The absolute path to the user configuration directory.
     """
 
-    config_dir = user_config_dir(APP_NAME, appauthor=False)
-    if create:
+    legacy_path = get_legacy_settings_path()
+    if _should_use_portable_settings(legacy_path, _LOGGER):
+        config_dir = os.path.dirname(legacy_path)
+    else:
+        config_dir = user_config_dir(APP_NAME, appauthor=False)
+
+    if create and config_dir:
         os.makedirs(config_dir, exist_ok=True)
     return config_dir
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,6 @@ python_functions = test_*
 # Register async marker for coroutine-style tests
 markers =
     asyncio: execute test within asyncio event loop
+    no_settings_dir_isolation: allow tests to use real settings paths
 # Skip problematic directories to avoid import conflicts
 norecursedirs = .git .tox dist build *.egg __pycache__ py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,8 +74,16 @@ sys.modules['nodes'] = nodes_mock
 
 
 @pytest.fixture(autouse=True)
-def _isolate_settings_dir(tmp_path_factory, monkeypatch):
+def _isolate_settings_dir(tmp_path_factory, monkeypatch, request):
     """Redirect settings.json into a temporary directory for each test."""
+
+    if request.node.get_closest_marker("no_settings_dir_isolation"):
+        from py.services import settings_manager as settings_manager_module
+
+        settings_manager_module.reset_settings_manager()
+        yield
+        settings_manager_module.reset_settings_manager()
+        return
 
     settings_dir = tmp_path_factory.mktemp("settings_dir")
 


### PR DESCRIPTION
## Summary
- route portable settings requests to the repository root so configuration and cache directories live alongside the project
- ensure the persistent model cache resolves to the project tree in portable mode or when configuration resolution fails
- extend the pytest configuration to support opting out of settings isolation and add a regression test covering the portable paths

## Testing
- pytest tests/services/test_settings_manager.py -v

------
https://chatgpt.com/codex/tasks/task_e_6906acc82c54832090bef29c3f3cb4d5