### PR TITLE
修复：在应用LoRA值到文本时仅包含激活的LoRA

### DIFF
--- a/web/comfyui/lora_syntax_utils.js
+++ b/web/comfyui/lora_syntax_utils.js
@@ -63,6 +63,12 @@ export function applyLoraValuesToText(originalText, loras) {
     if (!lora || !lora.name) {
       return;
     }
+    // Only include active LoRAs in the map
+    // If active property is missing (undefined/null), treat as active for backward compatibility
+    const isActive = lora.active === undefined || lora.active === null || lora.active === true;
+    if (!isActive) {
+      return;
+    }
     loraMap.set(lora.name, lora);
   });
 


### PR DESCRIPTION
- 在applyLoraValuesToText函数中添加激活状态检查
- 如果LoRA的active属性为false，则跳过该LoRA
- 保持向后兼容性：当active属性未定义或为null时，默认视为激活状态
- 确保只有用户选中的LoRA会被应用到工作流文本中