### PR TITLE
Feature/download managing

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -689,6 +689,13 @@
             },
             "minimize": "Minimieren",
             "clickToRestore": "Zum Wiederherstellen klicken",
+            "queue": {
+                "title": "Download-Warteschlange",
+                "downloading": "Wird heruntergeladen: {name}",
+                "queued": "Warteschlange #{position}: {name}",
+                "waiting": "Warten...",
+                "pending": "Ausstehend"
+            },
             "progress": {
                 "currentFile": "Aktuelle Datei:",
                 "downloading": "Wird heruntergeladen: {name}",
@@ -919,6 +926,10 @@
                 },
                 "actions": {
                     "download": "Herunterladen",
+                    "downloading": "Wird heruntergeladen...",
+                    "downloadingTooltip": "Diese Version wird gerade heruntergeladen",
+                    "queued": "Warteschlange",
+                    "queuedTooltip": "Diese Version ist in der Download-Warteschlange",
                     "delete": "Löschen",
                     "ignore": "Ignorieren",
                     "unignore": "Ignorierung aufheben",
@@ -1311,7 +1322,8 @@
             "imagesCompleted": "Beispielbilder {action} abgeschlossen",
             "imagesFailed": "Beispielbilder {action} fehlgeschlagen",
             "loadError": "Fehler beim Laden der Downloads: {message}",
-            "downloadError": "Download-Fehler: {message}"
+            "downloadError": "Download-Fehler: {message}",
+            "downloadCancelled": "Download abgebrochen"
         },
         "import": {
             "folderTreeFailed": "Fehler beim Laden des Ordnerbaums",

--- a/locales/de.json
+++ b/locales/de.json
@@ -687,6 +687,8 @@
                 "downloadingFile": "{type}-Datei wird heruntergeladen",
                 "finalizing": "Download wird abgeschlossen..."
             },
+            "minimize": "Minimieren",
+            "clickToRestore": "Zum Wiederherstellen klicken",
             "progress": {
                 "currentFile": "Aktuelle Datei:",
                 "downloading": "Wird heruntergeladen: {name}",

--- a/locales/de.json
+++ b/locales/de.json
@@ -1328,7 +1328,9 @@
             "loadError": "Fehler beim Laden der Downloads: {message}",
             "downloadError": "Download-Fehler: {message}",
             "downloadCancelled": "Download abgebrochen",
-            "cancelFailed": "Download konnte nicht abgebrochen werden: {error}"
+            "cancelFailed": "Download konnte nicht abgebrochen werden: {error}",
+            "removedFromQueue": "Aus Download-Warteschlange entfernt",
+            "removeFailed": "Entfernen aus Warteschlange fehlgeschlagen: {error}"
         },
         "import": {
             "folderTreeFailed": "Fehler beim Laden des Ordnerbaums",

--- a/locales/de.json
+++ b/locales/de.json
@@ -685,10 +685,14 @@
                 "preparing": "Download wird vorbereitet...",
                 "downloadedPreview": "Vorschaubild heruntergeladen",
                 "downloadingFile": "{type}-Datei wird heruntergeladen",
-                "finalizing": "Download wird abgeschlossen..."
+                "finalizing": "Download wird abgeschlossen...",
+                "cancelling": "Download wird abgebrochen...",
+                "cancelled": "Download abgebrochen"
             },
             "minimize": "Minimieren",
             "clickToRestore": "Zum Wiederherstellen klicken",
+            "cancel": "Abbrechen",
+            "remove": "Aus Warteschlange entfernen",
             "queue": {
                 "title": "Download-Warteschlange",
                 "downloading": "Wird heruntergeladen: {name}",
@@ -1323,7 +1327,8 @@
             "imagesFailed": "Beispielbilder {action} fehlgeschlagen",
             "loadError": "Fehler beim Laden der Downloads: {message}",
             "downloadError": "Download-Fehler: {message}",
-            "downloadCancelled": "Download abgebrochen"
+            "downloadCancelled": "Download abgebrochen",
+            "cancelFailed": "Download konnte nicht abgebrochen werden: {error}"
         },
         "import": {
             "folderTreeFailed": "Fehler beim Laden des Ordnerbaums",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1327,7 +1327,9 @@
             "loadError": "Error loading downloads: {message}",
             "downloadError": "Download error: {message}",
             "downloadCancelled": "Download cancelled",
-            "cancelFailed": "Failed to cancel download: {error}"
+            "cancelFailed": "Failed to cancel download: {error}",
+            "removedFromQueue": "Removed from download queue",
+            "removeFailed": "Failed to remove from queue: {error}"
         },
         "import": {
             "folderTreeFailed": "Failed to load folder tree",

--- a/locales/en.json
+++ b/locales/en.json
@@ -684,10 +684,14 @@
                 "preparing": "Preparing download...",
                 "downloadedPreview": "Downloaded preview image",
                 "downloadingFile": "Downloading {type} file",
-                "finalizing": "Finalizing download..."
+                "finalizing": "Finalizing download...",
+                "cancelling": "Cancelling download...",
+                "cancelled": "Download cancelled"
             },
             "minimize": "Minimize",
             "clickToRestore": "Click to restore",
+            "cancel": "Cancel",
+            "remove": "Remove from queue",
             "queue": {
                 "title": "Download Queue",
                 "downloading": "Downloading: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "Example images {action} failed",
             "loadError": "Error loading downloads: {message}",
             "downloadError": "Download error: {message}",
-            "downloadCancelled": "Download cancelled"
+            "downloadCancelled": "Download cancelled",
+            "cancelFailed": "Failed to cancel download: {error}"
         },
         "import": {
             "folderTreeFailed": "Failed to load folder tree",

--- a/locales/en.json
+++ b/locales/en.json
@@ -688,6 +688,13 @@
             },
             "minimize": "Minimize",
             "clickToRestore": "Click to restore",
+            "queue": {
+                "title": "Download Queue",
+                "downloading": "Downloading: {name}",
+                "queued": "Queued #{position}: {name}",
+                "waiting": "Waiting...",
+                "pending": "Pending"
+            },
             "progress": {
                 "currentFile": "Current file:",
                 "downloading": "Downloading: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "Download",
+                    "downloading": "Downloading...",
+                    "downloadingTooltip": "This version is currently downloading",
+                    "queued": "Queued",
+                    "queuedTooltip": "This version is queued for download",
                     "delete": "Delete",
                     "ignore": "Ignore",
                     "unignore": "Unignore",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "Example images {action} completed",
             "imagesFailed": "Example images {action} failed",
             "loadError": "Error loading downloads: {message}",
-            "downloadError": "Download error: {message}"
+            "downloadError": "Download error: {message}",
+            "downloadCancelled": "Download cancelled"
         },
         "import": {
             "folderTreeFailed": "Failed to load folder tree",

--- a/locales/en.json
+++ b/locales/en.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "Downloading {type} file",
                 "finalizing": "Finalizing download..."
             },
+            "minimize": "Minimize",
+            "clickToRestore": "Click to restore",
             "progress": {
                 "currentFile": "Current file:",
                 "downloading": "Downloading: {name}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -688,6 +688,13 @@
             },
             "minimize": "Minimizar",
             "clickToRestore": "Haga clic para restaurar",
+            "queue": {
+                "title": "Cola de descarga",
+                "downloading": "Descargando: {name}",
+                "queued": "En cola #{position}: {name}",
+                "waiting": "Esperando...",
+                "pending": "Pendiente"
+            },
             "progress": {
                 "currentFile": "Archivo actual:",
                 "downloading": "Descargando: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "Descargar",
+                    "downloading": "Descargando...",
+                    "downloadingTooltip": "Esta versión se está descargando actualmente",
+                    "queued": "En cola",
+                    "queuedTooltip": "Esta versión está en cola de descarga",
                     "delete": "Eliminar",
                     "ignore": "Ignorar",
                     "unignore": "Dejar de ignorar",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "Imágenes de ejemplo {action} completadas",
             "imagesFailed": "Imágenes de ejemplo {action} fallidas",
             "loadError": "Error al cargar descargas: {message}",
-            "downloadError": "Error de descarga: {message}"
+            "downloadError": "Error de descarga: {message}",
+            "downloadCancelled": "Descarga cancelada"
         },
         "import": {
             "folderTreeFailed": "Error al cargar árbol de carpetas",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1327,7 +1327,9 @@
             "loadError": "Error al cargar descargas: {message}",
             "downloadError": "Error de descarga: {message}",
             "downloadCancelled": "Descarga cancelada",
-            "cancelFailed": "Error al cancelar la descarga: {error}"
+            "cancelFailed": "Error al cancelar la descarga: {error}",
+            "removedFromQueue": "Eliminado de la cola de descarga",
+            "removeFailed": "Error al eliminar de la cola: {error}"
         },
         "import": {
             "folderTreeFailed": "Error al cargar árbol de carpetas",

--- a/locales/es.json
+++ b/locales/es.json
@@ -684,10 +684,14 @@
                 "preparing": "Preparando descarga...",
                 "downloadedPreview": "Imagen de vista previa descargada",
                 "downloadingFile": "Descargando archivo de {type}",
-                "finalizing": "Finalizando descarga..."
+                "finalizing": "Finalizando descarga...",
+                "cancelling": "Cancelando descarga...",
+                "cancelled": "Descarga cancelada"
             },
             "minimize": "Minimizar",
             "clickToRestore": "Haga clic para restaurar",
+            "cancel": "Cancelar",
+            "remove": "Eliminar de la cola",
             "queue": {
                 "title": "Cola de descarga",
                 "downloading": "Descargando: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "Imágenes de ejemplo {action} fallidas",
             "loadError": "Error al cargar descargas: {message}",
             "downloadError": "Error de descarga: {message}",
-            "downloadCancelled": "Descarga cancelada"
+            "downloadCancelled": "Descarga cancelada",
+            "cancelFailed": "Error al cancelar la descarga: {error}"
         },
         "import": {
             "folderTreeFailed": "Error al cargar árbol de carpetas",

--- a/locales/es.json
+++ b/locales/es.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "Descargando archivo de {type}",
                 "finalizing": "Finalizando descarga..."
             },
+            "minimize": "Minimizar",
+            "clickToRestore": "Haga clic para restaurar",
             "progress": {
                 "currentFile": "Archivo actual:",
                 "downloading": "Descargando: {name}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "Téléchargement du fichier {type}",
                 "finalizing": "Finalisation du téléchargement..."
             },
+            "minimize": "Réduire",
+            "clickToRestore": "Cliquez pour restaurer",
             "progress": {
                 "currentFile": "Fichier actuel :",
                 "downloading": "Téléchargement : {name}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -688,6 +688,13 @@
             },
             "minimize": "Réduire",
             "clickToRestore": "Cliquez pour restaurer",
+            "queue": {
+                "title": "File d'attente de téléchargement",
+                "downloading": "Téléchargement : {name}",
+                "queued": "En file d'attente #{position} : {name}",
+                "waiting": "En attente...",
+                "pending": "En attente"
+            },
             "progress": {
                 "currentFile": "Fichier actuel :",
                 "downloading": "Téléchargement : {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "Télécharger",
+                    "downloading": "Téléchargement en cours...",
+                    "downloadingTooltip": "Cette version est en cours de téléchargement",
+                    "queued": "En attente",
+                    "queuedTooltip": "Cette version est en file d'attente de téléchargement",
                     "delete": "Supprimer",
                     "ignore": "Ignorer",
                     "unignore": "Ne plus ignorer",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "Images d'exemple {action} terminées",
             "imagesFailed": "Images d'exemple {action} échouées",
             "loadError": "Erreur lors du chargement des téléchargements : {message}",
-            "downloadError": "Erreur de téléchargement : {message}"
+            "downloadError": "Erreur de téléchargement : {message}",
+            "downloadCancelled": "Téléchargement annulé"
         },
         "import": {
             "folderTreeFailed": "Échec du chargement de l'arborescence des dossiers",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1327,7 +1327,9 @@
             "loadError": "Erreur lors du chargement des téléchargements : {message}",
             "downloadError": "Erreur de téléchargement : {message}",
             "downloadCancelled": "Téléchargement annulé",
-            "cancelFailed": "Échec de l'annulation du téléchargement : {error}"
+            "cancelFailed": "Échec de l'annulation du téléchargement : {error}",
+            "removedFromQueue": "Retiré de la file d'attente de téléchargement",
+            "removeFailed": "Échec du retrait de la file d'attente : {error}"
         },
         "import": {
             "folderTreeFailed": "Échec du chargement de l'arborescence des dossiers",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -684,10 +684,14 @@
                 "preparing": "Préparation du téléchargement...",
                 "downloadedPreview": "Image d'aperçu téléchargée",
                 "downloadingFile": "Téléchargement du fichier {type}",
-                "finalizing": "Finalisation du téléchargement..."
+                "finalizing": "Finalisation du téléchargement...",
+                "cancelling": "Annulation du téléchargement...",
+                "cancelled": "Téléchargement annulé"
             },
             "minimize": "Réduire",
             "clickToRestore": "Cliquez pour restaurer",
+            "cancel": "Annuler",
+            "remove": "Retirer de la file d'attente",
             "queue": {
                 "title": "File d'attente de téléchargement",
                 "downloading": "Téléchargement : {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "Images d'exemple {action} échouées",
             "loadError": "Erreur lors du chargement des téléchargements : {message}",
             "downloadError": "Erreur de téléchargement : {message}",
-            "downloadCancelled": "Téléchargement annulé"
+            "downloadCancelled": "Téléchargement annulé",
+            "cancelFailed": "Échec de l'annulation du téléchargement : {error}"
         },
         "import": {
             "folderTreeFailed": "Échec du chargement de l'arborescence des dossiers",

--- a/locales/he.json
+++ b/locales/he.json
@@ -1327,7 +1327,9 @@
             "loadError": "שגיאה בטעינת הורדות: {message}",
             "downloadError": "שגיאת הורדה: {message}",
             "downloadCancelled": "ההורדה בוטלה",
-            "cancelFailed": "ביטול ההורדה נכשל: {error}"
+            "cancelFailed": "ביטול ההורדה נכשל: {error}",
+            "removedFromQueue": "הוסר מתור ההורדות",
+            "removeFailed": "הסרה מתור ההורדות נכשלה: {error}"
         },
         "import": {
             "folderTreeFailed": "טעינת עץ התיקיות נכשלה",

--- a/locales/he.json
+++ b/locales/he.json
@@ -684,10 +684,14 @@
                 "preparing": "מכין הורדה...",
                 "downloadedPreview": "תמונת תצוגה מקדימה הורדה",
                 "downloadingFile": "מוריד קובץ {type}",
-                "finalizing": "מסיים הורדה..."
+                "finalizing": "מסיים הורדה...",
+                "cancelling": "מבטל הורדה...",
+                "cancelled": "ההורדה בוטלה"
             },
             "minimize": "מזער",
             "clickToRestore": "לחץ לשחזור",
+            "cancel": "בטל",
+            "remove": "הסר מהתור",
             "queue": {
                 "title": "תור הורדות",
                 "downloading": "מוריד: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "{action} תמונות הדוגמה נכשל",
             "loadError": "שגיאה בטעינת הורדות: {message}",
             "downloadError": "שגיאת הורדה: {message}",
-            "downloadCancelled": "ההורדה בוטלה"
+            "downloadCancelled": "ההורדה בוטלה",
+            "cancelFailed": "ביטול ההורדה נכשל: {error}"
         },
         "import": {
             "folderTreeFailed": "טעינת עץ התיקיות נכשלה",

--- a/locales/he.json
+++ b/locales/he.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "מוריד קובץ {type}",
                 "finalizing": "מסיים הורדה..."
             },
+            "minimize": "מזער",
+            "clickToRestore": "לחץ לשחזור",
             "progress": {
                 "currentFile": "הקובץ הנוכחי:",
                 "downloading": "מוריד: {name}",

--- a/locales/he.json
+++ b/locales/he.json
@@ -688,6 +688,13 @@
             },
             "minimize": "מזער",
             "clickToRestore": "לחץ לשחזור",
+            "queue": {
+                "title": "תור הורדות",
+                "downloading": "מוריד: {name}",
+                "queued": "בתור #{position}: {name}",
+                "waiting": "ממתין...",
+                "pending": "ממתין"
+            },
             "progress": {
                 "currentFile": "הקובץ הנוכחי:",
                 "downloading": "מוריד: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "הורדה",
+                    "downloading": "מוריד...",
+                    "downloadingTooltip": "גרסה זו נמצאת כעת בתהליך הורדה",
+                    "queued": "בתור",
+                    "queuedTooltip": "גרסה זו נמצאת בתור להורדה",
                     "delete": "מחיקה",
                     "ignore": "התעלם",
                     "unignore": "בטל התעלמות",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "{action} תמונות הדוגמה הושלם",
             "imagesFailed": "{action} תמונות הדוגמה נכשל",
             "loadError": "שגיאה בטעינת הורדות: {message}",
-            "downloadError": "שגיאת הורדה: {message}"
+            "downloadError": "שגיאת הורדה: {message}",
+            "downloadCancelled": "ההורדה בוטלה"
         },
         "import": {
             "folderTreeFailed": "טעינת עץ התיקיות נכשלה",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -684,10 +684,14 @@
                 "preparing": "ダウンロードを準備中...",
                 "downloadedPreview": "プレビュー画像をダウンロードしました",
                 "downloadingFile": "{type}ファイルをダウンロード中",
-                "finalizing": "ダウンロードを完了中..."
+                "finalizing": "ダウンロードを完了中...",
+                "cancelling": "ダウンロードをキャンセル中...",
+                "cancelled": "ダウンロードがキャンセルされました"
             },
             "minimize": "最小化",
             "clickToRestore": "クリックして復元",
+            "cancel": "キャンセル",
+            "remove": "キューから削除",
             "queue": {
                 "title": "ダウンロードキュー",
                 "downloading": "ダウンロード中: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "例画像 {action} が失敗しました",
             "loadError": "ダウンロード読み込みエラー：{message}",
             "downloadError": "ダウンロードエラー：{message}",
-            "downloadCancelled": "ダウンロードがキャンセルされました"
+            "downloadCancelled": "ダウンロードがキャンセルされました",
+            "cancelFailed": "ダウンロードのキャンセルに失敗しました：{error}"
         },
         "import": {
             "folderTreeFailed": "フォルダツリーの読み込みに失敗しました",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -688,6 +688,13 @@
             },
             "minimize": "最小化",
             "clickToRestore": "クリックして復元",
+            "queue": {
+                "title": "ダウンロードキュー",
+                "downloading": "ダウンロード中: {name}",
+                "queued": "キュー #{position}: {name}",
+                "waiting": "待機中...",
+                "pending": "保留中"
+            },
             "progress": {
                 "currentFile": "現在のファイル:",
                 "downloading": "ダウンロード中: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "ダウンロード",
+                    "downloading": "ダウンロード中...",
+                    "downloadingTooltip": "このバージョンは現在ダウンロード中です",
+                    "queued": "待機中",
+                    "queuedTooltip": "このバージョンはダウンロード待ちです",
                     "delete": "削除",
                     "ignore": "無視",
                     "unignore": "無視を解除",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "例画像 {action} が完了しました",
             "imagesFailed": "例画像 {action} が失敗しました",
             "loadError": "ダウンロード読み込みエラー：{message}",
-            "downloadError": "ダウンロードエラー：{message}"
+            "downloadError": "ダウンロードエラー：{message}",
+            "downloadCancelled": "ダウンロードがキャンセルされました"
         },
         "import": {
             "folderTreeFailed": "フォルダツリーの読み込みに失敗しました",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "{type}ファイルをダウンロード中",
                 "finalizing": "ダウンロードを完了中..."
             },
+            "minimize": "最小化",
+            "clickToRestore": "クリックして復元",
             "progress": {
                 "currentFile": "現在のファイル:",
                 "downloading": "ダウンロード中: {name}",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1327,7 +1327,9 @@
             "loadError": "ダウンロード読み込みエラー：{message}",
             "downloadError": "ダウンロードエラー：{message}",
             "downloadCancelled": "ダウンロードがキャンセルされました",
-            "cancelFailed": "ダウンロードのキャンセルに失敗しました：{error}"
+            "cancelFailed": "ダウンロードのキャンセルに失敗しました：{error}",
+            "removedFromQueue": "ダウンロードキューから削除されました",
+            "removeFailed": "キューからの削除に失敗しました：{error}"
         },
         "import": {
             "folderTreeFailed": "フォルダツリーの読み込みに失敗しました",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "{type} 파일 다운로드 중",
                 "finalizing": "다운로드 완료 중..."
             },
+            "minimize": "최소화",
+            "clickToRestore": "클릭하여 복원",
             "progress": {
                 "currentFile": "현재 파일:",
                 "downloading": "다운로드 중: {name}",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -688,6 +688,13 @@
             },
             "minimize": "최소화",
             "clickToRestore": "클릭하여 복원",
+            "queue": {
+                "title": "다운로드 대기열",
+                "downloading": "다운로드 중: {name}",
+                "queued": "대기열 #{position}: {name}",
+                "waiting": "대기 중...",
+                "pending": "대기 중"
+            },
             "progress": {
                 "currentFile": "현재 파일:",
                 "downloading": "다운로드 중: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "다운로드",
+                    "downloading": "다운로드 중...",
+                    "downloadingTooltip": "이 버전은 현재 다운로드 중입니다",
+                    "queued": "대기 중",
+                    "queuedTooltip": "이 버전은 다운로드 대기 중입니다",
                     "delete": "삭제",
                     "ignore": "무시",
                     "unignore": "무시 해제",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "예시 이미지 {action}이(가) 완료되었습니다",
             "imagesFailed": "예시 이미지 {action}이(가) 실패했습니다",
             "loadError": "다운로드 로딩 오류: {message}",
-            "downloadError": "다운로드 오류: {message}"
+            "downloadError": "다운로드 오류: {message}",
+            "downloadCancelled": "다운로드가 취소되었습니다"
         },
         "import": {
             "folderTreeFailed": "폴더 트리 로딩 실패",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -684,10 +684,14 @@
                 "preparing": "다운로드 준비 중...",
                 "downloadedPreview": "미리보기 이미지 다운로드됨",
                 "downloadingFile": "{type} 파일 다운로드 중",
-                "finalizing": "다운로드 완료 중..."
+                "finalizing": "다운로드 완료 중...",
+                "cancelling": "다운로드 취소 중...",
+                "cancelled": "다운로드가 취소되었습니다"
             },
             "minimize": "최소화",
             "clickToRestore": "클릭하여 복원",
+            "cancel": "취소",
+            "remove": "대기열에서 제거",
             "queue": {
                 "title": "다운로드 대기열",
                 "downloading": "다운로드 중: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "예시 이미지 {action}이(가) 실패했습니다",
             "loadError": "다운로드 로딩 오류: {message}",
             "downloadError": "다운로드 오류: {message}",
-            "downloadCancelled": "다운로드가 취소되었습니다"
+            "downloadCancelled": "다운로드가 취소되었습니다",
+            "cancelFailed": "다운로드 취소 실패: {error}"
         },
         "import": {
             "folderTreeFailed": "폴더 트리 로딩 실패",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -1327,7 +1327,9 @@
             "loadError": "다운로드 로딩 오류: {message}",
             "downloadError": "다운로드 오류: {message}",
             "downloadCancelled": "다운로드가 취소되었습니다",
-            "cancelFailed": "다운로드 취소 실패: {error}"
+            "cancelFailed": "다운로드 취소 실패: {error}",
+            "removedFromQueue": "다운로드 대기열에서 제거됨",
+            "removeFailed": "대기열에서 제거 실패: {error}"
         },
         "import": {
             "folderTreeFailed": "폴더 트리 로딩 실패",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1327,7 +1327,9 @@
             "loadError": "Ошибка загрузки downloads: {message}",
             "downloadError": "Ошибка загрузки: {message}",
             "downloadCancelled": "Загрузка отменена",
-            "cancelFailed": "Не удалось отменить загрузку: {error}"
+            "cancelFailed": "Не удалось отменить загрузку: {error}",
+            "removedFromQueue": "Удалено из очереди загрузки",
+            "removeFailed": "Не удалось удалить из очереди: {error}"
         },
         "import": {
             "folderTreeFailed": "Не удалось загрузить дерево папок",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -688,6 +688,13 @@
             },
             "minimize": "Свернуть",
             "clickToRestore": "Нажмите, чтобы восстановить",
+            "queue": {
+                "title": "Очередь загрузки",
+                "downloading": "Загрузка: {name}",
+                "queued": "В очереди #{position}: {name}",
+                "waiting": "Ожидание...",
+                "pending": "Ожидает"
+            },
             "progress": {
                 "currentFile": "Текущий файл:",
                 "downloading": "Скачивается: {name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "Скачать",
+                    "downloading": "Загрузка...",
+                    "downloadingTooltip": "Эта версия сейчас загружается",
+                    "queued": "В очереди",
+                    "queuedTooltip": "Эта версия находится в очереди загрузки",
                     "delete": "Удалить",
                     "ignore": "Игнорировать",
                     "unignore": "Перестать игнорировать",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "Примеры изображений {action} завершены",
             "imagesFailed": "Примеры изображений {action} не удались",
             "loadError": "Ошибка загрузки downloads: {message}",
-            "downloadError": "Ошибка загрузки: {message}"
+            "downloadError": "Ошибка загрузки: {message}",
+            "downloadCancelled": "Загрузка отменена"
         },
         "import": {
             "folderTreeFailed": "Не удалось загрузить дерево папок",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "Загрузка файла {type}",
                 "finalizing": "Завершение загрузки..."
             },
+            "minimize": "Свернуть",
+            "clickToRestore": "Нажмите, чтобы восстановить",
             "progress": {
                 "currentFile": "Текущий файл:",
                 "downloading": "Скачивается: {name}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -684,10 +684,14 @@
                 "preparing": "Подготовка загрузки...",
                 "downloadedPreview": "Превью изображение загружено",
                 "downloadingFile": "Загрузка файла {type}",
-                "finalizing": "Завершение загрузки..."
+                "finalizing": "Завершение загрузки...",
+                "cancelling": "Отмена загрузки...",
+                "cancelled": "Загрузка отменена"
             },
             "minimize": "Свернуть",
             "clickToRestore": "Нажмите, чтобы восстановить",
+            "cancel": "Отмена",
+            "remove": "Удалить из очереди",
             "queue": {
                 "title": "Очередь загрузки",
                 "downloading": "Загрузка: {name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "Примеры изображений {action} не удались",
             "loadError": "Ошибка загрузки downloads: {message}",
             "downloadError": "Ошибка загрузки: {message}",
-            "downloadCancelled": "Загрузка отменена"
+            "downloadCancelled": "Загрузка отменена",
+            "cancelFailed": "Не удалось отменить загрузку: {error}"
         },
         "import": {
             "folderTreeFailed": "Не удалось загрузить дерево папок",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "正在下载 {type} 文件",
                 "finalizing": "正在完成下载..."
             },
+            "minimize": "最小化",
+            "clickToRestore": "点击恢复",
             "progress": {
                 "currentFile": "当前文件：",
                 "downloading": "下载中：{name}",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -684,10 +684,14 @@
                 "preparing": "正在准备下载...",
                 "downloadedPreview": "预览图片已下载",
                 "downloadingFile": "正在下载 {type} 文件",
-                "finalizing": "正在完成下载..."
+                "finalizing": "正在完成下载...",
+                "cancelling": "正在取消下载...",
+                "cancelled": "下载已取消"
             },
             "minimize": "最小化",
             "clickToRestore": "点击恢复",
+            "cancel": "取消",
+            "remove": "从队列中移除",
             "queue": {
                 "title": "下载队列",
                 "downloading": "正在下载：{name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "示例图片{action}失败",
             "loadError": "加载下载项出错：{message}",
             "downloadError": "下载错误：{message}",
-            "downloadCancelled": "下载已取消"
+            "downloadCancelled": "下载已取消",
+            "cancelFailed": "取消下载失败：{error}"
         },
         "import": {
             "folderTreeFailed": "加载文件夹树失败",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -688,6 +688,13 @@
             },
             "minimize": "最小化",
             "clickToRestore": "点击恢复",
+            "queue": {
+                "title": "下载队列",
+                "downloading": "正在下载：{name}",
+                "queued": "队列 #{position}：{name}",
+                "waiting": "等待中...",
+                "pending": "等待中"
+            },
             "progress": {
                 "currentFile": "当前文件：",
                 "downloading": "下载中：{name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "下载",
+                    "downloading": "下载中...",
+                    "downloadingTooltip": "此版本正在下载中",
+                    "queued": "已排队",
+                    "queuedTooltip": "此版本已加入下载队列",
                     "delete": "删除",
                     "ignore": "忽略",
                     "unignore": "取消忽略",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "示例图片{action}完成",
             "imagesFailed": "示例图片{action}失败",
             "loadError": "加载下载项出错：{message}",
-            "downloadError": "下载错误：{message}"
+            "downloadError": "下载错误：{message}",
+            "downloadCancelled": "下载已取消"
         },
         "import": {
             "folderTreeFailed": "加载文件夹树失败",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1327,7 +1327,9 @@
             "loadError": "加载下载项出错：{message}",
             "downloadError": "下载错误：{message}",
             "downloadCancelled": "下载已取消",
-            "cancelFailed": "取消下载失败：{error}"
+            "cancelFailed": "取消下载失败：{error}",
+            "removedFromQueue": "已从下载队列中移除",
+            "removeFailed": "从队列中移除失败：{error}"
         },
         "import": {
             "folderTreeFailed": "加载文件夹树失败",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -1327,7 +1327,9 @@
             "loadError": "載入下載時發生錯誤：{message}",
             "downloadError": "下載錯誤：{message}",
             "downloadCancelled": "下載已取消",
-            "cancelFailed": "取消下載失敗：{error}"
+            "cancelFailed": "取消下載失敗：{error}",
+            "removedFromQueue": "已從下載佇列中移除",
+            "removeFailed": "從佇列中移除失敗：{error}"
         },
         "import": {
             "folderTreeFailed": "載入資料夾樹狀結構失敗",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -684,10 +684,14 @@
                 "preparing": "準備下載中...",
                 "downloadedPreview": "已下載預覽圖片",
                 "downloadingFile": "正在下載 {type} 檔案",
-                "finalizing": "完成下載中..."
+                "finalizing": "完成下載中...",
+                "cancelling": "正在取消下載...",
+                "cancelled": "下載已取消"
             },
             "minimize": "最小化",
             "clickToRestore": "點擊恢復",
+            "cancel": "取消",
+            "remove": "從佇列中移除",
             "queue": {
                 "title": "下載佇列",
                 "downloading": "正在下載：{name}",
@@ -1322,7 +1326,8 @@
             "imagesFailed": "範例圖片{action}失敗",
             "loadError": "載入下載時發生錯誤：{message}",
             "downloadError": "下載錯誤：{message}",
-            "downloadCancelled": "下載已取消"
+            "downloadCancelled": "下載已取消",
+            "cancelFailed": "取消下載失敗：{error}"
         },
         "import": {
             "folderTreeFailed": "載入資料夾樹狀結構失敗",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -688,6 +688,13 @@
             },
             "minimize": "最小化",
             "clickToRestore": "點擊恢復",
+            "queue": {
+                "title": "下載佇列",
+                "downloading": "正在下載：{name}",
+                "queued": "佇列 #{position}：{name}",
+                "waiting": "等待中...",
+                "pending": "等待中"
+            },
             "progress": {
                 "currentFile": "目前檔案：",
                 "downloading": "下載中：{name}",
@@ -918,6 +925,10 @@
                 },
                 "actions": {
                     "download": "下載",
+                    "downloading": "下載中...",
+                    "downloadingTooltip": "此版本正在下載中",
+                    "queued": "已排隊",
+                    "queuedTooltip": "此版本已加入下載佇列",
                     "delete": "刪除",
                     "ignore": "忽略",
                     "unignore": "取消忽略",
@@ -1310,7 +1321,8 @@
             "imagesCompleted": "範例圖片{action}完成",
             "imagesFailed": "範例圖片{action}失敗",
             "loadError": "載入下載時發生錯誤：{message}",
-            "downloadError": "下載錯誤：{message}"
+            "downloadError": "下載錯誤：{message}",
+            "downloadCancelled": "下載已取消"
         },
         "import": {
             "folderTreeFailed": "載入資料夾樹狀結構失敗",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -686,6 +686,8 @@
                 "downloadingFile": "正在下載 {type} 檔案",
                 "finalizing": "完成下載中..."
             },
+            "minimize": "最小化",
+            "clickToRestore": "點擊恢復",
             "progress": {
                 "currentFile": "目前檔案：",
                 "downloading": "下載中：{name}",

--- a/py/routes/handlers/model_handlers.py
+++ b/py/routes/handlers/model_handlers.py
@@ -845,6 +845,17 @@ class ModelDownloadHandler:
             self._logger.error("Error listing active downloads: %s", exc, exc_info=True)
             return web.json_response({"success": False, "error": str(exc)}, status=500)
 
+    async def remove_queued_download_get(self, request: web.Request) -> web.Response:
+        try:
+            download_id = request.query.get("download_id")
+            if not download_id:
+                return web.json_response({"success": False, "error": "Download ID is required"}, status=400)
+            result = await self._download_coordinator.remove_queued_download(download_id)
+            return web.json_response(result)
+        except Exception as exc:
+            self._logger.error("Error removing queued download via GET: %s", exc, exc_info=True)
+            return web.json_response({"success": False, "error": str(exc)}, status=500)
+
     async def get_download_progress(self, request: web.Request) -> web.Response:
         try:
             download_id = request.match_info.get("download_id")
@@ -1600,6 +1611,7 @@ class ModelHandlerSet:
             "pause_download_get": self.download.pause_download_get,
             "resume_download_get": self.download.resume_download_get,
             "list_active_downloads_get": self.download.list_active_downloads_get,
+            "remove_queued_download_get": self.download.remove_queued_download_get,
             "get_download_progress": self.download.get_download_progress,
             "get_civitai_versions": self.civitai.get_civitai_versions,
             "get_civitai_model_by_version": self.civitai.get_civitai_model_by_version,

--- a/py/routes/handlers/model_handlers.py
+++ b/py/routes/handlers/model_handlers.py
@@ -837,6 +837,14 @@ class ModelDownloadHandler:
             self._logger.error("Error resuming download via GET: %s", exc, exc_info=True)
             return web.json_response({"success": False, "error": str(exc)}, status=500)
 
+    async def list_active_downloads_get(self, request: web.Request) -> web.Response:
+        try:
+            result = await self._download_coordinator.list_active_downloads()
+            return web.json_response(result)
+        except Exception as exc:
+            self._logger.error("Error listing active downloads: %s", exc, exc_info=True)
+            return web.json_response({"success": False, "error": str(exc)}, status=500)
+
     async def get_download_progress(self, request: web.Request) -> web.Response:
         try:
             download_id = request.match_info.get("download_id")
@@ -1591,6 +1599,7 @@ class ModelHandlerSet:
             "cancel_download_get": self.download.cancel_download_get,
             "pause_download_get": self.download.pause_download_get,
             "resume_download_get": self.download.resume_download_get,
+            "list_active_downloads_get": self.download.list_active_downloads_get,
             "get_download_progress": self.download.get_download_progress,
             "get_civitai_versions": self.civitai.get_civitai_versions,
             "get_civitai_model_by_version": self.civitai.get_civitai_model_by_version,

--- a/py/routes/model_route_registrar.py
+++ b/py/routes/model_route_registrar.py
@@ -68,6 +68,7 @@ COMMON_ROUTE_DEFINITIONS: tuple[RouteDefinition, ...] = (
     RouteDefinition("GET", "/api/lm/resume-download", "resume_download_get"),
     RouteDefinition("GET", "/api/lm/download-progress/{download_id}", "get_download_progress"),
     RouteDefinition("GET", "/api/lm/active-downloads", "list_active_downloads_get"),
+    RouteDefinition("GET", "/api/lm/remove-queued-download", "remove_queued_download_get"),
     RouteDefinition("GET", "/{prefix}", "handle_models_page"),
 )
 

--- a/py/routes/model_route_registrar.py
+++ b/py/routes/model_route_registrar.py
@@ -67,6 +67,7 @@ COMMON_ROUTE_DEFINITIONS: tuple[RouteDefinition, ...] = (
     RouteDefinition("GET", "/api/lm/pause-download", "pause_download_get"),
     RouteDefinition("GET", "/api/lm/resume-download", "resume_download_get"),
     RouteDefinition("GET", "/api/lm/download-progress/{download_id}", "get_download_progress"),
+    RouteDefinition("GET", "/api/lm/active-downloads", "list_active_downloads_get"),
     RouteDefinition("GET", "/{prefix}", "handle_models_page"),
 )
 

--- a/py/services/download_coordinator.py
+++ b/py/services/download_coordinator.py
@@ -165,6 +165,25 @@ class DownloadCoordinator:
         download_manager = await self._download_manager_factory()
         return await download_manager.get_active_downloads()
 
+    async def remove_queued_download(self, download_id: str) -> Dict[str, Any]:
+        """Remove a queued download and notify listeners."""
+        download_manager = await self._download_manager_factory()
+        result = await download_manager.remove_queued_download(download_id)
+        
+        if result.get('success'):
+            # Broadcast removal event
+            await self._ws_manager.broadcast_download_progress(
+                download_id,
+                {
+                    "status": "removed",
+                    "progress": 0,
+                    "download_id": download_id,
+                    "message": "Download removed from queue",
+                },
+            )
+        
+        return result
+
     def _parse_optional_int(self, value: Any, field: str) -> Optional[int]:
         """Parse an optional integer from user input."""
 

--- a/py/services/download_manager.py
+++ b/py/services/download_manager.py
@@ -154,8 +154,11 @@ class DownloadManager:
             if task_id in self._download_tasks:
                 del self._download_tasks[task_id]
             self._pause_events.pop(task_id, None)
-            # Ensure cancelled download is removed from tracking (in case it wasn't already)
-            self._active_downloads.pop(task_id, None)
+            # Only remove cancelled downloads from tracking in finally block
+            # Completed downloads remain until _cleanup_download_record removes them
+            download_info = self._active_downloads.get(task_id)
+            if download_info and download_info.get('status') == 'cancelled':
+                self._active_downloads.pop(task_id, None)
 
     async def _download_with_semaphore(self, task_id: str, model_id: int, model_version_id: int,
                                      save_dir: str, relative_path: str,

--- a/static/js/components/shared/ModelVersionsTab.js
+++ b/static/js/components/shared/ModelVersionsTab.js
@@ -241,16 +241,19 @@ function renderRow(version, options) {
     );
 
     const actions = [];
-    if (!version.isInLibrary) {
+    // Show Delete button if file exists locally, otherwise show Download button
+    // This ensures Download button appears even after deletion (when filePath is null but isInLibrary might still be true)
+    if (version.filePath) {
+        actions.push(
+            `<button class="version-action version-action-danger" data-version-action="delete">${escapeHtml(deleteLabel)}</button>`
+        );
+    } else {
+        // Show Download button when file doesn't exist locally (not downloaded or was deleted)
         const disabledAttr = downloadDisabled ? 'disabled' : '';
         const titleAttr = downloadTitle ? `title="${escapeHtml(downloadTitle)}"` : '';
         const disabledClass = downloadDisabled ? ' version-action-disabled' : '';
         actions.push(
             `<button class="version-action version-action-primary${disabledClass}" data-version-action="download" ${disabledAttr} ${titleAttr}>${escapeHtml(downloadLabel)}</button>`
-        );
-    } else if (version.filePath) {
-        actions.push(
-            `<button class="version-action version-action-danger" data-version-action="delete">${escapeHtml(deleteLabel)}</button>`
         );
     }
     actions.push(

--- a/static/js/managers/DownloadManager.js
+++ b/static/js/managers/DownloadManager.js
@@ -39,8 +39,6 @@ export class DownloadManager {
     }
 
     showDownloadModal() {
-        console.log('Showing unified download modal...');
-        
         // Get API client for current page type
         this.apiClient = getModelApiClient();
         const config = this.apiClient.apiConfig.config;
@@ -367,10 +365,7 @@ export class DownloadManager {
             const singularType = this.apiClient.modelType.replace(/s$/, '');
             const defaultRootKey = `default_${singularType}_root`;
             const defaultRoot = state.global.settings[defaultRootKey];
-            console.log(`Default root for ${this.apiClient.modelType}:`, defaultRoot);
-            console.log('Available roots:', rootsData.roots);
             if (defaultRoot && rootsData.roots.includes(defaultRoot)) {
-                console.log(`Setting default root: ${defaultRoot}`);
                 modelRoot.value = defaultRoot;
             }
 
@@ -466,7 +461,6 @@ export class DownloadManager {
                 // Always use the current active download ID from loadingManager
                 // This gets updated when updateQueueDisplay runs
                 const activeId = this.loadingManager.activeDownloadId || this.currentDownloadId || downloadId;
-                console.log('Cancel button clicked, canceling download:', activeId);
                 this.cancelDownload(activeId);
             };
             updateProgress = this.loadingManager.showDownloadProgress(1, cancelHandler);
@@ -480,15 +474,12 @@ export class DownloadManager {
 
             ws.onmessage = event => {
                 const data = JSON.parse(event.data);
-                console.log('WebSocket message received:', data); // Debug log
 
                 if (data.type === 'download_id') {
                     // Update downloadId to match backend's ID
                     const backendDownloadId = data.download_id;
-                    console.log(`Connected to download progress with ID: ${backendDownloadId}`);
                     // Use backend's download_id for matching messages
                     if (backendDownloadId && backendDownloadId !== downloadId) {
-                        console.log(`Updating downloadId from ${downloadId} to ${backendDownloadId}`);
                         downloadId = backendDownloadId;
                         this.currentDownloadId = backendDownloadId; // Update tracked download ID
                     }
@@ -742,26 +733,21 @@ export class DownloadManager {
                     // Update cancel callback to always fetch current active download and cancel it
                     // This ensures we cancel the correct download even if the queue changes
                     this.loadingManager.onCancelCallback = async () => {
-                        console.log('Cancel button clicked');
                         // Fetch current active downloads to ensure we cancel the right one
                         try {
                             const currentData = await this.checkQueueStatus();
                             if (currentData && currentData.downloads && Array.isArray(currentData.downloads)) {
                                 const currentActive = currentData.downloads.find(d => d.status === 'downloading');
                                 if (currentActive && currentActive.download_id) {
-                                    console.log('Canceling active download:', currentActive.download_id);
                                     await this.cancelDownload(currentActive.download_id);
                                 } else {
-                                    console.warn('No active download found when cancel button clicked');
                                     // Fallback to stored ID
                                     if (activeDownloadId) {
-                                        console.log('Using stored active download ID:', activeDownloadId);
                                         await this.cancelDownload(activeDownloadId);
                                     }
                                 }
                             } else {
                                 // Fallback to stored ID if fetch fails
-                                console.log('Failed to fetch current downloads, using stored ID:', activeDownloadId);
                                 await this.cancelDownload(activeDownloadId);
                             }
                         } catch (error) {
@@ -770,10 +756,8 @@ export class DownloadManager {
                             await this.cancelDownload(activeDownloadId);
                         }
                     };
-                    console.log('Updated cancel callback to use active download ID:', activeDownloadId);
                 } else {
                     // No active download - clear the cancel callback or set it to null
-                    console.log('No active download found, clearing cancel callback');
                     this.loadingManager.onCancelCallback = null;
                 }
                 
@@ -833,7 +817,6 @@ export class DownloadManager {
             return;
         }
         
-        console.log('cancelDownload called with downloadId:', downloadId, 'currentDownloadId:', this.currentDownloadId, 'activeDownloadId:', this.loadingManager.activeDownloadId);
         this.isCancelling = true;
         
         // Clear any existing timeout

--- a/static/js/managers/DownloadManager.js
+++ b/static/js/managers/DownloadManager.js
@@ -25,6 +25,7 @@ export class DownloadManager {
         this.folderTreeManager = new FolderTreeManager();
         this.folderClickHandler = null;
         this.updateTargetPath = this.updateTargetPath.bind(this);
+        this.queuePollInterval = null; // Interval for polling download queue
         
         // Bound methods for event handling
         this.handleValidateAndFetchVersions = this.validateAndFetchVersions.bind(this);
@@ -447,44 +448,91 @@ export class DownloadManager {
         const displayName = versionName || `#${versionId}`;
         let ws = null;
         let updateProgress = () => {};
+        let downloadId = Date.now().toString(); // Use let so it can be updated
 
         try {
             this.loadingManager.restoreProgressBar();
             updateProgress = this.loadingManager.showDownloadProgress(1);
+            this.currentUpdateProgress = updateProgress; // Store reference for queue updates
             updateProgress(0, 0, displayName);
-
-            const downloadId = Date.now().toString();
             const wsProtocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
             ws = new WebSocket(`${wsProtocol}${window.location.host}/ws/download-progress?id=${downloadId}`);
 
+            // Start polling for queue updates
+            this.startQueuePolling();
+
             ws.onmessage = event => {
                 const data = JSON.parse(event.data);
+                console.log('WebSocket message received:', data); // Debug log
 
                 if (data.type === 'download_id') {
-                    console.log(`Connected to download progress with ID: ${data.download_id}`);
+                    // Update downloadId to match backend's ID
+                    const backendDownloadId = data.download_id;
+                    console.log(`Connected to download progress with ID: ${backendDownloadId}`);
+                    // Use backend's download_id for matching messages
+                    if (backendDownloadId && backendDownloadId !== downloadId) {
+                        console.log(`Updating downloadId from ${downloadId} to ${backendDownloadId}`);
+                        downloadId = backendDownloadId;
+                    }
                     return;
                 }
 
-                if (data.status === 'progress' && data.download_id === downloadId) {
-                    const metrics = {
-                        bytesDownloaded: data.bytes_downloaded,
-                        totalBytes: data.total_bytes,
-                        bytesPerSecond: data.bytes_per_second,
-                    };
-
-                    updateProgress(data.progress, 0, displayName, metrics);
-
-                    if (data.progress < 3) {
-                        this.loadingManager.setStatus(translate('modals.download.status.preparing'));
-                    } else if (data.progress === 3) {
-                        this.loadingManager.setStatus(translate('modals.download.status.downloadedPreview'));
-                    } else if (data.progress > 3 && data.progress < 100) {
-                        this.loadingManager.setStatus(
-                            translate('modals.download.status.downloadingFile', { type: config.singularName })
-                        );
-                    } else {
-                        this.loadingManager.setStatus(translate('modals.download.status.finalizing'));
+                // Match by download_id - only update if this matches the active download
+                // The queue polling will handle updating the main display with the correct active download
+                if (data.status === 'progress' && data.download_id) {
+                    // Update downloadId if we receive a message with a different ID (backend might have generated one)
+                    if (data.download_id !== downloadId) {
+                        downloadId = data.download_id;
                     }
+                    
+                    // Only update if this is the active download (queue polling handles the main display)
+                    // WebSocket messages are used for real-time updates, but queue polling ensures correct active download
+                    const activeDownloadId = this.loadingManager.activeDownloadId;
+                    if (!activeDownloadId || data.download_id === activeDownloadId) {
+                        const metrics = {
+                            bytesDownloaded: data.bytes_downloaded,
+                            totalBytes: data.total_bytes,
+                            bytesPerSecond: data.bytes_per_second,
+                        };
+
+                        updateProgress(data.progress, 0, displayName, metrics);
+
+                        if (data.progress < 3) {
+                            this.loadingManager.setStatus(translate('modals.download.status.preparing'));
+                        } else if (data.progress === 3) {
+                            this.loadingManager.setStatus(translate('modals.download.status.downloadedPreview'));
+                        } else if (data.progress > 3 && data.progress < 100) {
+                            this.loadingManager.setStatus(
+                                translate('modals.download.status.downloadingFile', { type: config.singularName })
+                            );
+                        } else {
+                            this.loadingManager.setStatus(translate('modals.download.status.finalizing'));
+                        }
+                    }
+                } else if (data.status === 'cancelled' || data.status === 'canceled') {
+                    // Handle cancellation - check if there are other downloads before hiding
+                    this.isCancelling = false;
+                    if (this.cancellationTimeout) {
+                        clearTimeout(this.cancellationTimeout);
+                        this.cancellationTimeout = null;
+                    }
+                    
+                    // Check queue before hiding (async check)
+                    this.checkQueueStatus().then(queueData => {
+                        const hasOtherDownloads = queueData && queueData.downloads && queueData.downloads.some(d => 
+                            d.status === 'downloading' || d.status === 'waiting' || d.status === 'queued'
+                        );
+                        
+                        if (!hasOtherDownloads) {
+                            this.loadingManager.hide();
+                        }
+                    });
+                    
+                    showToast('toast.downloads.downloadCancelled', {}, 'info');
+                } else if (data.status === 'completed' || data.status === 'success') {
+                    // Handle completion - don't hide here, let queue polling handle it
+                    updateProgress(100, 0, displayName);
+                    this.loadingManager.setStatus(translate('modals.download.status.finalizing'));
                 }
             };
 
@@ -543,7 +591,125 @@ export class DownloadManager {
             } catch (closeError) {
                 console.debug('Failed to close download progress socket:', closeError);
             }
-            this.loadingManager.hide();
+            
+            // Check if there are still active or queued downloads before hiding
+            // Only hide if this download was cancelled AND there are no other downloads
+            if (!this.isCancelling) {
+                // Download completed normally - check queue status
+                const queueData = await this.checkQueueStatus();
+                const hasActiveOrQueued = queueData && queueData.downloads && queueData.downloads.some(d => 
+                    d.status === 'downloading' || d.status === 'waiting' || d.status === 'queued'
+                );
+                
+                if (!hasActiveOrQueued) {
+                    // No active or queued downloads - safe to hide
+                    this.stopQueuePolling();
+                    this.currentUpdateProgress = null;
+                    this.loadingManager.hide();
+                } else {
+                    // There are other downloads - keep polling and showing
+                    // Don't clear currentUpdateProgress yet, as queue polling will handle updates
+                }
+            }
+            // If isCancelling, the cancellation handler above will check the queue
+        }
+    }
+
+    startQueuePolling() {
+        // Clear any existing interval
+        this.stopQueuePolling();
+        
+        // Poll immediately, but with a small delay to allow download to register
+        // This ensures the popup stays visible when starting the first download
+        setTimeout(() => {
+            this.updateQueueDisplay();
+        }, 100);
+        
+        // Then poll every 2 seconds
+        this.queuePollInterval = setInterval(() => {
+            this.updateQueueDisplay();
+        }, 2000);
+    }
+
+    stopQueuePolling() {
+        if (this.queuePollInterval) {
+            clearInterval(this.queuePollInterval);
+            this.queuePollInterval = null;
+        }
+    }
+
+    async checkQueueStatus() {
+        try {
+            const response = await fetch('/api/lm/active-downloads');
+            if (!response.ok) {
+                return null;
+            }
+            return await response.json();
+        } catch (error) {
+            console.debug('Failed to check queue status:', error);
+            return null;
+        }
+    }
+
+    async updateQueueDisplay() {
+        try {
+            const response = await fetch('/api/lm/active-downloads');
+            if (!response.ok) {
+                return;
+            }
+            
+            const data = await response.json();
+            if (data && data.downloads && Array.isArray(data.downloads)) {
+                // Update the queue display
+                this.loadingManager.updateQueueDisplay(data.downloads);
+                
+                // Check if there are active downloads OR queued downloads
+                // Keep popup visible as long as there are any downloads (active, waiting, or queued)
+                const hasActiveDownloads = data.downloads.some(d => 
+                    d.status === 'downloading' || d.status === 'waiting' || d.status === 'queued'
+                );
+                
+                if (!hasActiveDownloads) {
+                    // No active downloads - check if we should keep popup visible
+                    if (!this.currentUpdateProgress) {
+                        // No downloads and no download was just initiated - safe to hide
+                        this.stopQueuePolling();
+                        this.currentUpdateProgress = null;
+                        this.loadingManager.hide();
+                    } else {
+                        // Download was just initiated but not yet registered - keep popup visible
+                        // But respect minimized state - don't force restore if minimized
+                        if (this.loadingManager.overlay && !this.loadingManager.isMinimized) {
+                            this.loadingManager.overlay.style.display = 'flex';
+                        }
+                    }
+                } else {
+                    // There are active/queued downloads - ensure popup is visible
+                    // But respect minimized state - don't force restore if user minimized it
+                    if (this.loadingManager.overlay && !this.loadingManager.isMinimized) {
+                        this.loadingManager.overlay.style.display = 'flex';
+                    }
+                    // If minimized, the minimized widget will be updated by updateQueueDisplay
+                }
+            } else {
+                // No downloads data yet, but if we have a current update function, keep popup visible
+                if (this.currentUpdateProgress) {
+                    // Keep popup visible while waiting for download to register
+                    // But respect minimized state - don't force restore if minimized
+                    if (this.loadingManager.overlay && !this.loadingManager.isMinimized) {
+                        this.loadingManager.overlay.style.display = 'flex';
+                    }
+                }
+            }
+        } catch (error) {
+            console.debug('Failed to fetch active downloads:', error);
+            // On error, if we have a current update function, keep popup visible
+            // But respect minimized state - don't force restore if minimized
+            if (this.currentUpdateProgress) {
+                if (this.loadingManager.overlay && !this.loadingManager.isMinimized) {
+                    this.loadingManager.overlay.style.display = 'flex';
+                }
+            }
         }
     }
 

--- a/static/js/managers/LoadingManager.js
+++ b/static/js/managers/LoadingManager.js
@@ -40,6 +40,10 @@ export class LoadingManager {
         }
 
         this.detailsContainer = null; // Will be created when needed
+        this.isMinimized = false;
+        this.minimizedWidget = null;
+        this.currentFileName = '';
+        this.currentProgress = 0;
     }
 
     show(message = 'Loading...', progress = 0) {
@@ -55,6 +59,8 @@ export class LoadingManager {
         this.overlay.style.display = 'none';
         this.reset();
         this.removeDetailsContainer();
+        this.removeMinimizedWidget();
+        this.isMinimized = false;
     }
 
     setProgress(percent) {
@@ -102,9 +108,52 @@ export class LoadingManager {
     showDownloadProgress(totalItems = 1) {
         this.show(translate('modals.download.status.preparing', {}, 'Preparing download...'), 0);
         this.progressBar.style.display = 'none';
+        this.isMinimized = false;
         
         // Create details container
         const detailsContainer = this.createDetailsContainer();
+        
+        // Add minimize button
+        this.loadingContent.style.position = 'relative';
+        const minimizeButton = document.createElement('button');
+        minimizeButton.className = 'download-minimize-btn';
+        minimizeButton.innerHTML = '−'; // Unicode minus sign as fallback
+        minimizeButton.title = translate('modals.download.minimize', {}, 'Minimize');
+        minimizeButton.style.cssText = `
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: rgba(0, 0, 0, 0.3);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: rgba(255, 255, 255, 0.9);
+            cursor: pointer;
+            padding: 6px 10px;
+            font-size: 18px;
+            line-height: 1;
+            border-radius: 4px;
+            opacity: 0.8;
+            transition: opacity 0.2s, background 0.2s;
+            z-index: 10;
+            font-weight: bold;
+            min-width: 28px;
+            height: 28px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        `;
+        minimizeButton.addEventListener('mouseenter', () => {
+            minimizeButton.style.opacity = '1';
+            minimizeButton.style.background = 'rgba(0, 0, 0, 0.5)';
+        });
+        minimizeButton.addEventListener('mouseleave', () => {
+            minimizeButton.style.opacity = '0.8';
+            minimizeButton.style.background = 'rgba(0, 0, 0, 0.3)';
+        });
+        minimizeButton.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.minimize();
+        });
+        this.loadingContent.appendChild(minimizeButton);
         
         // Create current item progress
         const currentItemContainer = document.createElement('div');
@@ -218,8 +267,19 @@ export class LoadingManager {
         // Initialize transfer stats with empty data
         updateTransferStats();
         
+        // Store references for minimize widget updates
+        this.currentItemProgress = currentItemProgress;
+        this.currentItemLabel = currentItemLabel;
+        this.currentItemPercent = currentItemPercent;
+        
         // Return update function
         return (currentProgress, currentIndex = 0, currentName = '', metrics = {}) => {
+            // Store current state for minimized widget
+            this.currentProgress = currentProgress;
+            if (currentName) {
+                this.currentFileName = currentName;
+            }
+            
             // Update current item progress
             currentItemProgress.style.width = `${currentProgress}%`;
             currentItemPercent.textContent = `${Math.floor(currentProgress)}%`;
@@ -246,6 +306,11 @@ export class LoadingManager {
             }
 
             updateTransferStats(metrics);
+            
+            // Update minimized widget if it exists
+            if (this.isMinimized && this.minimizedWidget) {
+                this.updateMinimizedWidget();
+            }
         };
     }
 
@@ -293,5 +358,157 @@ export class LoadingManager {
 
     restoreProgressBar() {
         this.progressBar.style.display = 'block';
+    }
+    
+    minimize() {
+        if (this.isMinimized) return;
+        
+        this.isMinimized = true;
+        this.overlay.style.display = 'none';
+        this.createMinimizedWidget();
+    }
+    
+    restore() {
+        if (!this.isMinimized) return;
+        
+        this.isMinimized = false;
+        this.removeMinimizedWidget();
+        this.overlay.style.display = 'flex';
+    }
+    
+    createMinimizedWidget() {
+        // Remove existing widget if any
+        this.removeMinimizedWidget();
+        
+        // Create minimized widget container
+        this.minimizedWidget = document.createElement('div');
+        this.minimizedWidget.className = 'download-minimized-widget';
+        this.minimizedWidget.style.cssText = `
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            width: 300px;
+            background: var(--lora-surface, rgba(30, 30, 30, 0.95));
+            backdrop-filter: blur(24px);
+            border: 1px solid var(--lora-border, rgba(255, 255, 255, 0.1));
+            border-radius: var(--border-radius-base, 8px);
+            padding: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            z-index: calc(var(--z-overlay, 1000) - 1);
+            cursor: pointer;
+            transition: transform 0.2s, box-shadow 0.2s;
+        `;
+        this.minimizedWidget.addEventListener('click', () => {
+            this.restore();
+        });
+        this.minimizedWidget.addEventListener('mouseenter', () => {
+            this.minimizedWidget.style.transform = 'scale(1.02)';
+            this.minimizedWidget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.4)';
+        });
+        this.minimizedWidget.addEventListener('mouseleave', () => {
+            this.minimizedWidget.style.transform = 'scale(1)';
+            this.minimizedWidget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.3)';
+        });
+        
+        // Create file name display
+        const fileNameDisplay = document.createElement('div');
+        fileNameDisplay.className = 'minimized-file-name';
+        fileNameDisplay.style.cssText = `
+            font-size: 13px;
+            color: var(--text-color, rgba(255, 255, 255, 0.9));
+            margin-bottom: 8px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            font-weight: 500;
+        `;
+        fileNameDisplay.textContent = this.currentFileName || translate('modals.download.status.preparing', {}, 'Preparing download...');
+        
+        // Create progress bar container
+        const progressContainer = document.createElement('div');
+        progressContainer.className = 'minimized-progress-container';
+        progressContainer.style.cssText = `
+            width: 100%;
+            height: 6px;
+            background-color: var(--lora-border, rgba(255, 255, 255, 0.1));
+            border-radius: 3px;
+            overflow: hidden;
+            margin-bottom: 4px;
+        `;
+        
+        // Create progress bar
+        const progressBar = document.createElement('div');
+        progressBar.className = 'minimized-progress-bar';
+        progressBar.style.cssText = `
+            width: ${this.currentProgress}%;
+            height: 100%;
+            background-color: var(--lora-accent, #4a9eff);
+            transition: width 200ms ease-out;
+        `;
+        
+        // Create progress percentage
+        const progressPercent = document.createElement('div');
+        progressPercent.className = 'minimized-progress-percent';
+        progressPercent.style.cssText = `
+            font-size: 11px;
+            color: var(--text-color-secondary, rgba(255, 255, 255, 0.7));
+            text-align: right;
+        `;
+        progressPercent.textContent = `${Math.floor(this.currentProgress)}%`;
+        
+        progressContainer.appendChild(progressBar);
+        
+        // Store references for updates
+        this.minimizedFileNameDisplay = fileNameDisplay;
+        this.minimizedProgressBar = progressBar;
+        this.minimizedProgressPercent = progressPercent;
+        
+        // Assemble widget
+        this.minimizedWidget.appendChild(fileNameDisplay);
+        this.minimizedWidget.appendChild(progressContainer);
+        this.minimizedWidget.appendChild(progressPercent);
+        
+        // Add restore hint
+        const restoreHint = document.createElement('div');
+        restoreHint.style.cssText = `
+            font-size: 10px;
+            color: var(--text-color-secondary, rgba(255, 255, 255, 0.5));
+            text-align: center;
+            margin-top: 4px;
+        `;
+        restoreHint.textContent = translate('modals.download.clickToRestore', {}, 'Click to restore');
+        this.minimizedWidget.appendChild(restoreHint);
+        
+        document.body.appendChild(this.minimizedWidget);
+    }
+    
+    updateMinimizedWidget() {
+        if (!this.minimizedWidget || !this.isMinimized) return;
+        
+        if (this.minimizedFileNameDisplay && this.currentFileName) {
+            this.minimizedFileNameDisplay.textContent = translate(
+                'modals.download.progress.downloading',
+                { name: this.currentFileName },
+                `Downloading: ${this.currentFileName}`
+            );
+        }
+        
+        if (this.minimizedProgressBar) {
+            this.minimizedProgressBar.style.width = `${this.currentProgress}%`;
+        }
+        
+        if (this.minimizedProgressPercent) {
+            this.minimizedProgressPercent.textContent = `${Math.floor(this.currentProgress)}%`;
+        }
+    }
+    
+    removeMinimizedWidget() {
+        if (this.minimizedWidget) {
+            this.minimizedWidget.remove();
+            this.minimizedWidget = null;
+            this.minimizedFileNameDisplay = null;
+            this.minimizedProgressBar = null;
+            this.minimizedProgressPercent = null;
+        }
     }
 }

--- a/tests/frontend/managers/downloadManager.cancelRemove.test.js
+++ b/tests/frontend/managers/downloadManager.cancelRemove.test.js
@@ -1,0 +1,893 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+// Mock dependencies
+const showToastMock = vi.fn();
+const translateMock = vi.fn((key, params, fallback) => fallback || key);
+const loadingManagerMock = {
+  showDownloadProgress: vi.fn(() => vi.fn()),
+  restoreProgressBar: vi.fn(),
+  setStatus: vi.fn(),
+  hide: vi.fn(),
+  updateQueueDisplay: vi.fn(),
+  overlay: { style: { display: 'none' } },
+  isMinimized: false,
+  onCancelCallback: null,
+  onRemoveCallback: null,
+  activeDownloadId: null,
+};
+
+const apiClientMock = {
+  downloadModel: vi.fn(),
+  apiConfig: {
+    config: {
+      singularName: 'model',
+    },
+  },
+};
+
+const getModelApiClientMock = vi.fn(() => apiClientMock);
+
+vi.mock('../../../static/js/utils/uiHelpers.js', () => ({
+  showToast: showToastMock,
+}));
+
+vi.mock('../../../static/js/utils/i18nHelpers.js', () => ({
+  translate: translateMock,
+}));
+
+vi.mock('../../../static/js/managers/LoadingManager.js', () => ({
+  LoadingManager: vi.fn(() => loadingManagerMock),
+}));
+
+vi.mock('../../../static/js/api/modelApiFactory.js', () => ({
+  getModelApiClient: getModelApiClientMock,
+  resetAndReload: vi.fn(),
+}));
+
+describe('DownloadManager - Cancel and Remove Functionality', () => {
+  let DownloadManager;
+  let downloadManager;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Reset loading manager state
+    loadingManagerMock.showDownloadProgress.mockReturnValue(vi.fn());
+    loadingManagerMock.overlay.style.display = 'none';
+    loadingManagerMock.isMinimized = false;
+    loadingManagerMock.onCancelCallback = null;
+    loadingManagerMock.onRemoveCallback = null;
+    loadingManagerMock.activeDownloadId = null;
+
+    // Mock fetch globally
+    global.fetch = vi.fn();
+    global.WebSocket = vi.fn(() => ({
+      close: vi.fn(),
+      readyState: WebSocket.OPEN,
+      onmessage: null,
+      onerror: null,
+    }));
+
+    // Mock document methods
+    global.document = {
+      getElementById: vi.fn(() => ({
+        style: { display: 'none' },
+        value: '',
+        innerHTML: '',
+      })),
+      createElement: vi.fn((tag) => ({
+        tagName: tag,
+        style: {},
+        addEventListener: vi.fn(),
+        appendChild: vi.fn(),
+        remove: vi.fn(),
+        textContent: '',
+        innerHTML: '',
+      })),
+      body: {
+        appendChild: vi.fn(),
+      },
+      querySelector: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+    };
+
+    const module = await import('../../../static/js/managers/DownloadManager.js');
+    DownloadManager = module.DownloadManager;
+    downloadManager = new DownloadManager();
+    downloadManager.apiClient = apiClientMock;
+    downloadManager.loadingManager = loadingManagerMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Cancel Download', () => {
+    it('should cancel an active download successfully', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, message: 'Download cancelled' }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/lm/cancel-download-get?download_id=${downloadId}`)
+      );
+      expect(loadingManagerMock.setStatus).toHaveBeenCalledWith(
+        expect.stringContaining('Cancelling')
+      );
+    });
+
+    it('should handle cancel failure from backend', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: false, error: 'Download not found' }),
+      });
+
+      await downloadManager.cancelDownload(downloadId);
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.cancelFailed',
+        { error: 'Download not found' },
+        'error'
+      );
+      expect(downloadManager.isCancelling).toBe(false);
+    });
+
+    it('should handle network errors during cancel', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await downloadManager.cancelDownload(downloadId);
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.cancelFailed',
+        { error: 'Network error' },
+        'error'
+      );
+      expect(downloadManager.isCancelling).toBe(false);
+    });
+
+    it('should refresh queue display after cancellation', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      // Mock checkQueueStatus
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [
+          { download_id: 'dl-456', status: 'waiting' },
+        ],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      // Wait for timeout to complete
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should hide popup if no downloads remain after cancel', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      // Wait for timeout
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should verify cancelled download is removed from queue display', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      // Mock queue status showing no downloads after cancellation
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [], // Cancelled download should not appear
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      // Wait for timeout
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      // Verify updateQueueDisplay was called with empty downloads
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should handle errors in updateQueueDisplay gracefully', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      // Make updateQueueDisplay throw an error
+      downloadManager.updateQueueDisplay = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.cancelDownload(downloadId);
+
+      // Wait for timeout and error handling
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Remove Queued Download', () => {
+    it('should remove a queued download successfully', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, message: 'Removed from queue' }),
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/lm/remove-queued-download?download_id=${downloadId}`)
+      );
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removedFromQueue',
+        {},
+        'info'
+      );
+    });
+
+    it('should handle remove failure from backend', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: false, error: 'Download not found' }),
+      });
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removeFailed',
+        { error: 'Download not found' },
+        'error'
+      );
+    });
+
+    it('should handle network errors during remove', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removeFailed',
+        { error: 'Network error' },
+        'error'
+      );
+    });
+
+    it('should update queue display after successful removal', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should handle missing download ID gracefully', async () => {
+      await downloadManager.removeQueuedDownload(null);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should verify removed download is not in queue display', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      // Mock updateQueueDisplay to verify it's called
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      // Verify updateQueueDisplay was called to refresh queue
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should handle errors in updateQueueDisplay during remove', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      // Make updateQueueDisplay throw an error
+      downloadManager.updateQueueDisplay = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removedFromQueue',
+        {},
+        'info'
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Queue Display Updates', () => {
+    it('should correctly update queue display with active and queued downloads', async () => {
+      const mockDownloads = [
+        {
+          download_id: 'dl-active',
+          status: 'downloading',
+          progress: 50,
+          model_name: 'Model 1',
+          version_name: 'v1.0',
+        },
+        {
+          download_id: 'dl-waiting',
+          status: 'waiting',
+          progress: 0,
+          model_name: 'Model 2',
+          version_name: 'v2.0',
+        },
+        {
+          download_id: 'dl-queued',
+          status: 'queued',
+          progress: 0,
+          model_name: 'Model 3',
+          version_name: 'v3.0',
+        },
+      ];
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: mockDownloads }),
+      });
+
+      await downloadManager.updateQueueDisplay();
+
+      expect(loadingManagerMock.updateQueueDisplay).toHaveBeenCalledWith(mockDownloads);
+    });
+
+    it('should filter out cancelled downloads from queue display', async () => {
+      const mockDownloads = [
+        {
+          download_id: 'dl-active',
+          status: 'downloading',
+          progress: 50,
+          model_name: 'Model 1',
+          version_name: 'v1.0',
+        },
+        {
+          download_id: 'dl-cancelled',
+          status: 'cancelled', // Should be filtered out
+          progress: 0,
+          model_name: 'Model 2',
+          version_name: 'v2.0',
+        },
+      ];
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: mockDownloads }),
+      });
+
+      await downloadManager.updateQueueDisplay();
+
+      // Backend should filter cancelled downloads, but verify frontend handles it
+      expect(loadingManagerMock.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should handle empty downloads array correctly', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: [] }),
+      });
+
+      downloadManager.currentUpdateProgress = null;
+
+      await downloadManager.updateQueueDisplay();
+
+      expect(loadingManagerMock.updateQueueDisplay).toHaveBeenCalledWith([]);
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should hide popup when no downloads remain', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: [] }),
+      });
+
+      downloadManager.currentUpdateProgress = null;
+
+      await downloadManager.updateQueueDisplay();
+
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should keep popup visible when downloads are active', async () => {
+      const mockDownloads = [
+        {
+          download_id: 'dl-active',
+          status: 'downloading',
+          progress: 50,
+        },
+      ];
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: mockDownloads }),
+      });
+
+      await downloadManager.updateQueueDisplay();
+
+      expect(loadingManagerMock.hide).not.toHaveBeenCalled();
+      expect(loadingManagerMock.overlay.style.display).toBe('flex');
+    });
+
+    it('should respect minimized state when updating queue', async () => {
+      const mockDownloads = [
+        {
+          download_id: 'dl-active',
+          status: 'downloading',
+          progress: 50,
+        },
+      ];
+
+      loadingManagerMock.isMinimized = true;
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ downloads: mockDownloads }),
+      });
+
+      await downloadManager.updateQueueDisplay();
+
+      // Should not force restore if minimized
+      expect(loadingManagerMock.overlay.style.display).not.toBe('flex');
+    });
+  });
+
+  describe('Integration Scenarios', () => {
+    it('should handle cancel then remove scenario', async () => {
+      const activeId = 'dl-active';
+      const queuedId = 'dl-queued';
+
+      // Cancel active download
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [
+          { download_id: queuedId, status: 'waiting' },
+        ],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(activeId);
+
+      // Wait for timeout
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      // Remove queued download
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      await downloadManager.removeQueuedDownload(queuedId);
+
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket cancellation message correctly', async () => {
+      const downloadId = 'dl-123';
+      const ws = {
+        close: vi.fn(),
+        readyState: WebSocket.OPEN,
+        onmessage: null,
+        onerror: null,
+      };
+
+      global.WebSocket = vi.fn(() => ws);
+
+      downloadManager.executeDownloadWithProgress = vi.fn(async () => {
+        // Simulate WebSocket cancellation message
+        if (ws.onmessage) {
+          ws.onmessage({
+            data: JSON.stringify({
+              status: 'cancelled',
+              download_id: downloadId,
+            }),
+          });
+        }
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.executeDownloadWithProgress({
+        modelId: 1,
+        versionId: 1,
+        versionName: 'v1.0',
+      });
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket cancellation with queued items', async () => {
+      const downloadId = 'dl-123';
+      const queuedId = 'dl-queued';
+      const ws = {
+        close: vi.fn(),
+        readyState: WebSocket.OPEN,
+        onmessage: null,
+        onerror: null,
+      };
+
+      global.WebSocket = vi.fn(() => ws);
+
+      downloadManager.executeDownloadWithProgress = vi.fn(async () => {
+        if (ws.onmessage) {
+          ws.onmessage({
+            data: JSON.stringify({
+              status: 'cancelled',
+              download_id: downloadId,
+            }),
+          });
+        }
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [
+          { download_id: queuedId, status: 'waiting' },
+        ],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.executeDownloadWithProgress({
+        modelId: 1,
+        versionId: 1,
+        versionName: 'v1.0',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should NOT hide if there are queued items
+      expect(loadingManagerMock.hide).not.toHaveBeenCalled();
+      expect(downloadManager.updateQueueDisplay).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket cancellation message', async () => {
+      const downloadId = 'dl-123';
+      const ws = {
+        close: vi.fn(),
+        readyState: WebSocket.OPEN,
+        onmessage: null,
+        onerror: null,
+      };
+
+      global.WebSocket = vi.fn(() => ws);
+
+      // Simulate WebSocket cancellation message
+      downloadManager.executeDownloadWithProgress = vi.fn(async () => {
+        // Simulate WebSocket message
+        if (ws.onmessage) {
+          ws.onmessage({
+            data: JSON.stringify({
+              status: 'cancelled',
+              download_id: downloadId,
+            }),
+          });
+        }
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.executeDownloadWithProgress({
+        modelId: 1,
+        versionId: 1,
+        versionName: 'v1.0',
+      });
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle fetch errors gracefully', async () => {
+      global.fetch.mockRejectedValueOnce(new Error('Fetch failed'));
+
+      await downloadManager.cancelDownload('dl-123');
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.cancelFailed',
+        { error: 'Fetch failed' },
+        'error'
+      );
+    });
+
+    it('should handle invalid JSON responses', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      await expect(downloadManager.cancelDownload('dl-123')).rejects.toThrow();
+    });
+
+    it('should handle timeout scenarios', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({
+                ok: true,
+                json: async () => ({ success: true }),
+              });
+            }, 3000); // Longer than timeout
+          })
+      );
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      // Timeout should fire before fetch completes
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should handle errors in checkQueueStatus during cancel', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockRejectedValue(new Error('Queue check failed'));
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.cancelDownload(downloadId);
+
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should handle errors in updateQueueDisplay during cancel timeout', async () => {
+      const downloadId = 'dl-123';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [{ download_id: 'dl-other', status: 'waiting' }],
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.cancelDownload(downloadId);
+
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should handle network errors during remove', async () => {
+      global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await downloadManager.removeQueuedDownload('dl-queued');
+
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removeFailed',
+        { error: 'Network error' },
+        'error'
+      );
+    });
+
+    it('should handle errors in updateQueueDisplay during remove', async () => {
+      const downloadId = 'dl-queued';
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.removeQueuedDownload(downloadId);
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(showToastMock).toHaveBeenCalledWith(
+        'toast.downloads.removedFromQueue',
+        {},
+        'info'
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Cancellation Issue Fix Tests', () => {
+    it('should ensure cancelled downloads are not shown in queue', async () => {
+      const downloadId = 'dl-123';
+
+      // Mock backend returning empty downloads after cancellation
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [], // Backend should filter out cancelled downloads
+      });
+
+      downloadManager.updateQueueDisplay = vi.fn().mockResolvedValue(undefined);
+
+      await downloadManager.cancelDownload(downloadId);
+
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+
+      // Verify queue is checked and popup is hidden
+      expect(downloadManager.checkQueueStatus).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+    });
+
+    it('should handle WebSocket cancellation message with proper error handling', async () => {
+      const downloadId = 'dl-123';
+      const ws = {
+        close: vi.fn(),
+        readyState: WebSocket.OPEN,
+        onmessage: null,
+        onerror: null,
+      };
+
+      global.WebSocket = vi.fn(() => ws);
+
+      downloadManager.executeDownloadWithProgress = vi.fn(async () => {
+        if (ws.onmessage) {
+          ws.onmessage({
+            data: JSON.stringify({
+              status: 'cancelled',
+              download_id: downloadId,
+            }),
+          });
+        }
+      });
+
+      downloadManager.checkQueueStatus = vi.fn().mockResolvedValue({
+        downloads: [],
+      });
+
+      // Make updateQueueDisplay fail to test error handling
+      downloadManager.updateQueueDisplay = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await downloadManager.executeDownloadWithProgress({
+        modelId: 1,
+        versionId: 1,
+        versionName: 'v1.0',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Should handle error and still hide popup
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(loadingManagerMock.hide).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});
+

--- a/tests/services/test_download_cancel_remove.py
+++ b/tests/services/test_download_cancel_remove.py
@@ -1,0 +1,1051 @@
+"""Tests for download cancel and remove functionality."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from py.services.download_coordinator import DownloadCoordinator
+from py.services.download_manager import DownloadManager
+
+
+@dataclass
+class StubWebSocketManager:
+    """Stub WebSocket manager for testing."""
+    progress: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    broadcasts: List[tuple[str, Dict[str, Any]]] = field(default_factory=list)
+
+    def generate_download_id(self) -> str:
+        return "generated"
+
+    def get_download_progress(self, download_id: str) -> Dict[str, Any] | None:
+        return self.progress.get(download_id)
+
+    async def broadcast_download_progress(self, download_id: str, payload: Dict[str, Any]) -> None:
+        self.broadcasts.append((download_id, payload))
+
+
+@pytest.fixture
+def reset_download_manager():
+    """Ensure each test operates on a fresh singleton."""
+    DownloadManager._instance = None
+    yield
+    DownloadManager._instance = None
+
+
+@pytest.fixture
+def mock_download_manager():
+    """Create a mock download manager with realistic behavior."""
+    manager = MagicMock(spec=DownloadManager)
+    manager._active_downloads = {}
+    manager._download_tasks = {}
+    manager._pause_events = {}
+    
+    async def cancel_download(download_id: str) -> Dict[str, Any]:
+        if download_id not in manager._download_tasks:
+            return {'success': False, 'error': 'Download task not found'}
+        
+        # Simulate cancellation - remove from tracking immediately
+        task = manager._download_tasks.get(download_id)
+        if task:
+            task.cancel()
+        
+        # Remove cancelled download from active downloads immediately (as per new behavior)
+        manager._active_downloads.pop(download_id, None)
+        manager._download_tasks.pop(download_id, None)
+        manager._pause_events.pop(download_id, None)
+        
+        return {'success': True, 'message': 'Download cancelled successfully'}
+    
+    async def remove_queued_download(download_id: str) -> Dict[str, Any]:
+        if download_id not in manager._active_downloads:
+            return {'success': False, 'error': 'Download not found'}
+        
+        download_info = manager._active_downloads[download_id]
+        status = download_info.get('status', 'unknown')
+        
+        if status == 'downloading':
+            return {'success': False, 'error': 'Cannot remove active download. Use cancel instead.'}
+        
+        # Remove from tracking
+        task = manager._download_tasks.get(download_id)
+        if task:
+            task.cancel()
+        
+        manager._active_downloads.pop(download_id, None)
+        manager._download_tasks.pop(download_id, None)
+        manager._pause_events.pop(download_id, None)
+        
+        return {'success': True, 'message': 'Queued download removed successfully'}
+    
+    async def get_active_downloads() -> Dict[str, Any]:
+        # Filter out cancelled/completed downloads - only return active, waiting, or queued
+        active_statuses = {'downloading', 'waiting', 'queued'}
+        return {
+            'downloads': [
+                {
+                    'download_id': task_id,
+                    'model_id': info.get('model_id'),
+                    'model_version_id': info.get('model_version_id'),
+                    'model_name': info.get('model_name', ''),
+                    'version_name': info.get('version_name', ''),
+                    'progress': info.get('progress', 0),
+                    'status': info.get('status', 'unknown'),
+                    'error': info.get('error', None),
+                    'bytes_downloaded': info.get('bytes_downloaded', 0),
+                    'total_bytes': info.get('total_bytes'),
+                    'bytes_per_second': info.get('bytes_per_second', 0.0),
+                }
+                for task_id, info in manager._active_downloads.items()
+                if info.get('status', 'unknown') in active_statuses
+            ]
+        }
+    
+    manager.cancel_download = AsyncMock(side_effect=cancel_download)
+    manager.remove_queued_download = AsyncMock(side_effect=remove_queued_download)
+    manager.get_active_downloads = AsyncMock(side_effect=get_active_downloads)
+    
+    return manager
+
+
+@pytest.fixture
+def coordinator(mock_download_manager):
+    """Create a download coordinator with mocked dependencies."""
+    ws_manager = StubWebSocketManager()
+    
+    async def factory():
+        return mock_download_manager
+    
+    return DownloadCoordinator(ws_manager=ws_manager, download_manager_factory=factory)
+
+
+# ==================== Cancel Download Tests ====================
+
+async def test_cancel_active_download_success(coordinator, mock_download_manager):
+    """Test successfully canceling an active download."""
+    download_id = "dl-123"
+    
+    # Setup: Add an active download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    
+    result = await coordinator.cancel_download(download_id)
+    
+    assert result['success'] is True
+    assert mock_download_manager.cancel_download.called
+    assert len(coordinator._ws_manager.broadcasts) == 1
+    
+    broadcast = coordinator._ws_manager.broadcasts[0]
+    assert broadcast[0] == download_id
+    assert broadcast[1]['status'] == 'cancelled'
+    assert broadcast[1]['download_id'] == download_id
+
+
+async def test_cancel_download_not_found(coordinator, mock_download_manager):
+    """Test canceling a download that doesn't exist."""
+    download_id = "dl-nonexistent"
+    
+    result = await coordinator.cancel_download(download_id)
+    
+    assert result['success'] is False
+    assert 'not found' in result['error'].lower()
+    # Note: Coordinator always broadcasts cancellation, even on failure
+    # This is by design to notify clients of the cancellation attempt
+    assert len(coordinator._ws_manager.broadcasts) == 1
+
+
+async def test_cancel_download_with_queued_items(coordinator, mock_download_manager):
+    """Test canceling when there are queued downloads - next should auto-start."""
+    active_id = "dl-active"
+    queued_id = "dl-queued"
+    
+    # Setup: Active download and queued download
+    mock_task_active = MagicMock()
+    mock_task_queued = MagicMock()
+    
+    mock_download_manager._download_tasks[active_id] = mock_task_active
+    mock_download_manager._download_tasks[queued_id] = mock_task_queued
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'waiting',  # Next in queue
+        'progress': 0,
+    }
+    
+    result = await coordinator.cancel_download(active_id)
+    
+    assert result['success'] is True
+    # Should broadcast cancellation
+    assert len(coordinator._ws_manager.broadcasts) == 1
+    # Note: Backend semaphore will automatically start next download
+    # Frontend should refresh queue to see the transition
+
+
+async def test_cancel_download_broadcasts_cancellation(coordinator, mock_download_manager):
+    """Test that cancellation broadcasts the correct message."""
+    download_id = "dl-123"
+    
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 75,
+    }
+    
+    await coordinator.cancel_download(download_id)
+    
+    assert len(coordinator._ws_manager.broadcasts) == 1
+    broadcast = coordinator._ws_manager.broadcasts[0]
+    
+    assert broadcast[1]['status'] == 'cancelled'
+    assert broadcast[1]['progress'] == 0
+    assert broadcast[1]['message'] == 'Download cancelled by user'
+
+
+# ==================== Remove Queued Download Tests ====================
+
+async def test_remove_queued_download_success(coordinator, mock_download_manager):
+    """Test successfully removing a queued download."""
+    download_id = "dl-queued"
+    
+    # Setup: Add a queued download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    result = await coordinator.remove_queued_download(download_id)
+    
+    assert result['success'] is True
+    assert download_id not in mock_download_manager._active_downloads
+    assert download_id not in mock_download_manager._download_tasks
+    assert len(coordinator._ws_manager.broadcasts) == 1
+    
+    broadcast = coordinator._ws_manager.broadcasts[0]
+    assert broadcast[0] == download_id
+    assert broadcast[1]['status'] == 'removed'
+
+
+async def test_remove_waiting_download_success(coordinator, mock_download_manager):
+    """Test successfully removing a waiting download."""
+    download_id = "dl-waiting"
+    
+    # Setup: Add a waiting download (next in queue)
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    
+    result = await coordinator.remove_queued_download(download_id)
+    
+    assert result['success'] is True
+    assert download_id not in mock_download_manager._active_downloads
+
+
+async def test_remove_active_download_fails(coordinator, mock_download_manager):
+    """Test that removing an active download fails."""
+    download_id = "dl-active"
+    
+    # Setup: Add an active download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    
+    result = await coordinator.remove_queued_download(download_id)
+    
+    assert result['success'] is False
+    assert 'cannot remove active' in result['error'].lower()
+    # Should still exist
+    assert download_id in mock_download_manager._active_downloads
+    # Should not broadcast on failure
+    assert len(coordinator._ws_manager.broadcasts) == 0
+
+
+async def test_remove_nonexistent_download(coordinator, mock_download_manager):
+    """Test removing a download that doesn't exist."""
+    download_id = "dl-nonexistent"
+    
+    result = await coordinator.remove_queued_download(download_id)
+    
+    assert result['success'] is False
+    assert 'not found' in result['error'].lower()
+    assert len(coordinator._ws_manager.broadcasts) == 0
+
+
+async def test_remove_last_queued_item_updates_queue_count(coordinator, mock_download_manager):
+    """Test that removing the last queued item correctly updates queue count."""
+    active_id = "dl-active"
+    queued_id = "dl-queued"
+    
+    # Setup: Active download and one queued download
+    mock_download_manager._download_tasks[active_id] = MagicMock()
+    mock_download_manager._download_tasks[queued_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Get initial count
+    initial_downloads = await mock_download_manager.get_active_downloads()
+    assert len(initial_downloads['downloads']) == 2
+    
+    # Remove queued item
+    result = await coordinator.remove_queued_download(queued_id)
+    assert result['success'] is True
+    
+    # Get updated count
+    updated_downloads = await mock_download_manager.get_active_downloads()
+    assert len(updated_downloads['downloads']) == 1
+    assert updated_downloads['downloads'][0]['download_id'] == active_id
+
+
+async def test_remove_middle_queued_item_updates_order(coordinator, mock_download_manager):
+    """Test that removing a middle queued item correctly updates queue order."""
+    active_id = "dl-active"
+    queued1_id = "dl-queued-1"
+    queued2_id = "dl-queued-2"
+    queued3_id = "dl-queued-3"
+    
+    # Setup: Active download and three queued downloads
+    for dl_id in [active_id, queued1_id, queued2_id, queued3_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued1_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    mock_download_manager._active_downloads[queued2_id] = {
+        'model_id': 3,
+        'model_version_id': 3,
+        'status': 'queued',
+        'progress': 0,
+    }
+    mock_download_manager._active_downloads[queued3_id] = {
+        'model_id': 4,
+        'model_version_id': 4,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Get initial downloads
+    initial_downloads = await mock_download_manager.get_active_downloads()
+    assert len(initial_downloads['downloads']) == 4
+    
+    # Remove middle queued item
+    result = await coordinator.remove_queued_download(queued2_id)
+    assert result['success'] is True
+    
+    # Get updated downloads
+    updated_downloads = await mock_download_manager.get_active_downloads()
+    assert len(updated_downloads['downloads']) == 3
+    
+    # Verify remaining downloads
+    remaining_ids = {d['download_id'] for d in updated_downloads['downloads']}
+    assert active_id in remaining_ids
+    assert queued1_id in remaining_ids
+    assert queued3_id in remaining_ids
+    assert queued2_id not in remaining_ids
+
+
+async def test_remove_broadcasts_removal_event(coordinator, mock_download_manager):
+    """Test that removal broadcasts the correct event."""
+    download_id = "dl-queued"
+    
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    await coordinator.remove_queued_download(download_id)
+    
+    assert len(coordinator._ws_manager.broadcasts) == 1
+    broadcast = coordinator._ws_manager.broadcasts[0]
+    
+    assert broadcast[1]['status'] == 'removed'
+    assert broadcast[1]['message'] == 'Download removed from queue'
+
+
+async def test_remove_does_not_broadcast_on_failure(coordinator, mock_download_manager):
+    """Test that removal failures don't broadcast."""
+    download_id = "dl-nonexistent"
+    
+    result = await coordinator.remove_queued_download(download_id)
+    
+    assert result['success'] is False
+    assert len(coordinator._ws_manager.broadcasts) == 0
+
+
+# ==================== Integration Scenarios ====================
+
+async def test_cancel_then_remove_scenario(coordinator, mock_download_manager):
+    """Test scenario: Cancel active download, then remove a queued one."""
+    active_id = "dl-active"
+    queued1_id = "dl-queued-1"
+    queued2_id = "dl-queued-2"
+    
+    # Setup: One active, two queued
+    for dl_id in [active_id, queued1_id, queued2_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued1_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    mock_download_manager._active_downloads[queued2_id] = {
+        'model_id': 3,
+        'model_version_id': 3,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Cancel active
+    cancel_result = await coordinator.cancel_download(active_id)
+    assert cancel_result['success'] is True
+    
+    # Remove one queued
+    remove_result = await coordinator.remove_queued_download(queued1_id)
+    assert remove_result['success'] is True
+    
+    # Verify final state
+    final_downloads = await mock_download_manager.get_active_downloads()
+    assert len(final_downloads['downloads']) == 1
+    assert final_downloads['downloads'][0]['download_id'] == queued2_id
+
+
+async def test_remove_all_queued_items_leaves_only_active(coordinator, mock_download_manager):
+    """Test removing all queued items leaves only the active download."""
+    active_id = "dl-active"
+    queued1_id = "dl-queued-1"
+    queued2_id = "dl-queued-2"
+    
+    # Setup
+    for dl_id in [active_id, queued1_id, queued2_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued1_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    mock_download_manager._active_downloads[queued2_id] = {
+        'model_id': 3,
+        'model_version_id': 3,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove all queued items
+    result1 = await coordinator.remove_queued_download(queued1_id)
+    result2 = await coordinator.remove_queued_download(queued2_id)
+    
+    assert result1['success'] is True
+    assert result2['success'] is True
+    
+    # Verify only active remains
+    final_downloads = await mock_download_manager.get_active_downloads()
+    assert len(final_downloads['downloads']) == 1
+    assert final_downloads['downloads'][0]['download_id'] == active_id
+    assert final_downloads['downloads'][0]['status'] == 'downloading'
+
+
+# ==================== Error Handling Tests ====================
+
+async def test_cancel_handles_backend_error(coordinator, mock_download_manager):
+    """Test cancel handles backend errors gracefully."""
+    download_id = "dl-123"
+    
+    # Make cancel_download raise an exception
+    mock_download_manager.cancel_download = AsyncMock(side_effect=Exception("Backend error"))
+    
+    with pytest.raises(Exception):
+        await coordinator.cancel_download(download_id)
+
+
+async def test_remove_handles_backend_error(coordinator, mock_download_manager):
+    """Test remove handles backend errors gracefully."""
+    download_id = "dl-queued"
+    
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Make remove_queued_download raise an exception
+    mock_download_manager.remove_queued_download = AsyncMock(side_effect=Exception("Backend error"))
+    
+    with pytest.raises(Exception):
+        await coordinator.remove_queued_download(download_id)
+
+
+async def test_get_active_downloads_returns_correct_structure(coordinator, mock_download_manager):
+    """Test that get_active_downloads returns the correct structure."""
+    download_id = "dl-123"
+    
+    mock_download_manager._download_tasks[download_id] = MagicMock()
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 2,
+        'model_name': 'Test Model',
+        'version_name': 'v1.0',
+        'status': 'downloading',
+        'progress': 50,
+        'bytes_downloaded': 1024,
+        'total_bytes': 2048,
+        'bytes_per_second': 256.0,
+    }
+    
+    result = await mock_download_manager.get_active_downloads()
+    
+    assert 'downloads' in result
+    assert len(result['downloads']) == 1
+    
+    download = result['downloads'][0]
+    assert download['download_id'] == download_id
+    assert download['model_id'] == 1
+    assert download['model_version_id'] == 2
+    assert download['model_name'] == 'Test Model'
+    assert download['version_name'] == 'v1.0'
+    assert download['status'] == 'downloading'
+    assert download['progress'] == 50
+    assert download['bytes_downloaded'] == 1024
+    assert download['total_bytes'] == 2048
+    assert download['bytes_per_second'] == 256.0
+
+
+# ==================== Tests for Cancellation Issue Fix ====================
+
+async def test_cancelled_download_not_in_active_downloads(coordinator, mock_download_manager):
+    """Test that cancelled downloads are immediately removed from active_downloads."""
+    download_id = "dl-123"
+    
+    # Setup: Add an active download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    
+    # Verify it's in active downloads before cancellation
+    downloads_before = await mock_download_manager.get_active_downloads()
+    assert len(downloads_before['downloads']) == 1
+    assert downloads_before['downloads'][0]['download_id'] == download_id
+    
+    # Cancel the download
+    result = await coordinator.cancel_download(download_id)
+    assert result['success'] is True
+    
+    # Verify it's NOT in active downloads after cancellation
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+    assert download_id not in mock_download_manager._active_downloads
+
+
+async def test_cancelled_download_filtered_from_get_active_downloads(coordinator, mock_download_manager):
+    """Test that get_active_downloads filters out cancelled downloads."""
+    active_id = "dl-active"
+    cancelled_id = "dl-cancelled"
+    
+    # Setup: One active download and one cancelled download
+    mock_download_manager._download_tasks[active_id] = MagicMock()
+    mock_download_manager._download_tasks[cancelled_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[cancelled_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'cancelled',  # Cancelled status
+        'progress': 0,
+    }
+    
+    # get_active_downloads should filter out cancelled downloads
+    result = await mock_download_manager.get_active_downloads()
+    assert len(result['downloads']) == 1
+    assert result['downloads'][0]['download_id'] == active_id
+    assert cancelled_id not in [d['download_id'] for d in result['downloads']]
+
+
+async def test_cancelled_download_with_queued_items_removed_correctly(coordinator, mock_download_manager):
+    """Test that cancelling an active download removes it but keeps queued items."""
+    active_id = "dl-active"
+    queued_id = "dl-queued"
+    
+    # Setup: Active download and queued download
+    mock_task_active = MagicMock()
+    mock_task_queued = MagicMock()
+    
+    mock_download_manager._download_tasks[active_id] = mock_task_active
+    mock_download_manager._download_tasks[queued_id] = mock_task_queued
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    
+    # Cancel active download
+    result = await coordinator.cancel_download(active_id)
+    assert result['success'] is True
+    
+    # Verify active download is removed
+    assert active_id not in mock_download_manager._active_downloads
+    
+    # Verify queued download is still there
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 1
+    assert downloads_after['downloads'][0]['download_id'] == queued_id
+
+
+async def test_get_active_downloads_filters_multiple_statuses(coordinator, mock_download_manager):
+    """Test that get_active_downloads filters out various non-active statuses."""
+    downloading_id = "dl-downloading"
+    waiting_id = "dl-waiting"
+    queued_id = "dl-queued"
+    cancelled_id = "dl-cancelled"
+    completed_id = "dl-completed"
+    failed_id = "dl-failed"
+    
+    # Setup downloads with various statuses
+    for dl_id in [downloading_id, waiting_id, queued_id, cancelled_id, completed_id, failed_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[downloading_id] = {'status': 'downloading', 'model_id': 1, 'model_version_id': 1}
+    mock_download_manager._active_downloads[waiting_id] = {'status': 'waiting', 'model_id': 2, 'model_version_id': 2}
+    mock_download_manager._active_downloads[queued_id] = {'status': 'queued', 'model_id': 3, 'model_version_id': 3}
+    mock_download_manager._active_downloads[cancelled_id] = {'status': 'cancelled', 'model_id': 4, 'model_version_id': 4}
+    mock_download_manager._active_downloads[completed_id] = {'status': 'completed', 'model_id': 5, 'model_version_id': 5}
+    mock_download_manager._active_downloads[failed_id] = {'status': 'failed', 'model_id': 6, 'model_version_id': 6}
+    
+    result = await mock_download_manager.get_active_downloads()
+    
+    # Should only return downloading, waiting, and queued
+    assert len(result['downloads']) == 3
+    returned_ids = {d['download_id'] for d in result['downloads']}
+    assert downloading_id in returned_ids
+    assert waiting_id in returned_ids
+    assert queued_id in returned_ids
+    assert cancelled_id not in returned_ids
+    assert completed_id not in returned_ids
+    assert failed_id not in returned_ids
+
+
+# ==================== Tests for Remove Functionality Issues ====================
+
+async def test_removed_queued_download_not_in_active_downloads(coordinator, mock_download_manager):
+    """Test that removed queued downloads are immediately removed from active_downloads."""
+    queued_id = "dl-queued"
+    
+    # Setup: Add a queued download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[queued_id] = mock_task
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Verify it's in active downloads before removal
+    downloads_before = await mock_download_manager.get_active_downloads()
+    assert len(downloads_before['downloads']) == 1
+    assert downloads_before['downloads'][0]['download_id'] == queued_id
+    
+    # Remove the queued download
+    result = await coordinator.remove_queued_download(queued_id)
+    assert result['success'] is True
+    
+    # Verify it's NOT in active downloads after removal
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+    assert queued_id not in mock_download_manager._active_downloads
+    assert queued_id not in mock_download_manager._download_tasks
+
+
+async def test_removed_waiting_download_not_in_active_downloads(coordinator, mock_download_manager):
+    """Test that removed waiting downloads are immediately removed from active_downloads."""
+    waiting_id = "dl-waiting"
+    
+    # Setup: Add a waiting download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[waiting_id] = mock_task
+    mock_download_manager._active_downloads[waiting_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'waiting',
+        'progress': 0,
+    }
+    
+    # Remove the waiting download
+    result = await coordinator.remove_queued_download(waiting_id)
+    assert result['success'] is True
+    
+    # Verify it's NOT in active downloads after removal
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+    assert waiting_id not in mock_download_manager._active_downloads
+
+
+async def test_remove_queued_download_with_other_downloads_present(coordinator, mock_download_manager):
+    """Test removing a queued download when other downloads are present."""
+    active_id = "dl-active"
+    queued1_id = "dl-queued-1"
+    queued2_id = "dl-queued-2"
+    
+    # Setup: One active and two queued downloads
+    for dl_id in [active_id, queued1_id, queued2_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued1_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'queued',
+        'progress': 0,
+    }
+    mock_download_manager._active_downloads[queued2_id] = {
+        'model_id': 3,
+        'model_version_id': 3,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove one queued download
+    result = await coordinator.remove_queued_download(queued1_id)
+    assert result['success'] is True
+    
+    # Verify removed download is gone
+    assert queued1_id not in mock_download_manager._active_downloads
+    
+    # Verify other downloads are still present
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 2
+    returned_ids = {d['download_id'] for d in downloads_after['downloads']}
+    assert active_id in returned_ids
+    assert queued2_id in returned_ids
+    assert queued1_id not in returned_ids
+
+
+async def test_remove_last_queued_download_leaves_only_active(coordinator, mock_download_manager):
+    """Test that removing the last queued download leaves only the active download."""
+    active_id = "dl-active"
+    queued_id = "dl-queued"
+    
+    # Setup: One active and one queued download
+    mock_download_manager._download_tasks[active_id] = MagicMock()
+    mock_download_manager._download_tasks[queued_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove queued download
+    result = await coordinator.remove_queued_download(queued_id)
+    assert result['success'] is True
+    
+    # Verify only active download remains
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 1
+    assert downloads_after['downloads'][0]['download_id'] == active_id
+    assert queued_id not in mock_download_manager._active_downloads
+
+
+async def test_remove_all_queued_downloads_removes_all_from_tracking(coordinator, mock_download_manager):
+    """Test that removing all queued downloads removes them all from tracking."""
+    queued1_id = "dl-queued-1"
+    queued2_id = "dl-queued-2"
+    queued3_id = "dl-queued-3"
+    
+    # Setup: Three queued downloads
+    for dl_id in [queued1_id, queued2_id, queued3_id]:
+        mock_download_manager._download_tasks[dl_id] = MagicMock()
+        mock_download_manager._active_downloads[dl_id] = {
+            'model_id': 1,
+            'model_version_id': 1,
+            'status': 'queued',
+            'progress': 0,
+        }
+    
+    # Remove all queued downloads
+    result1 = await coordinator.remove_queued_download(queued1_id)
+    result2 = await coordinator.remove_queued_download(queued2_id)
+    result3 = await coordinator.remove_queued_download(queued3_id)
+    
+    assert result1['success'] is True
+    assert result2['success'] is True
+    assert result3['success'] is True
+    
+    # Verify all are removed from tracking
+    assert queued1_id not in mock_download_manager._active_downloads
+    assert queued2_id not in mock_download_manager._active_downloads
+    assert queued3_id not in mock_download_manager._active_downloads
+    assert queued1_id not in mock_download_manager._download_tasks
+    assert queued2_id not in mock_download_manager._download_tasks
+    assert queued3_id not in mock_download_manager._download_tasks
+    
+    # Verify no downloads remain
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+
+
+# ==================== Edge Case Tests ====================
+
+async def test_cancel_then_remove_same_download_id(coordinator, mock_download_manager):
+    """Test edge case: Try to cancel then remove the same download."""
+    download_id = "dl-123"
+    
+    # Setup: Add an active download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    
+    # Cancel the download
+    cancel_result = await coordinator.cancel_download(download_id)
+    assert cancel_result['success'] is True
+    
+    # Try to remove it (should fail - not found)
+    remove_result = await coordinator.remove_queued_download(download_id)
+    assert remove_result['success'] is False
+    assert 'not found' in remove_result['error'].lower()
+
+
+async def test_remove_then_cancel_same_download_id(coordinator, mock_download_manager):
+    """Test edge case: Try to remove then cancel the same download."""
+    download_id = "dl-123"
+    
+    # Setup: Add a queued download
+    mock_task = MagicMock()
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove the download
+    remove_result = await coordinator.remove_queued_download(download_id)
+    assert remove_result['success'] is True
+    
+    # Try to cancel it (should fail - not found)
+    cancel_result = await coordinator.cancel_download(download_id)
+    assert cancel_result['success'] is False
+    assert 'not found' in cancel_result['error'].lower()
+
+
+async def test_concurrent_cancel_and_remove_operations(coordinator, mock_download_manager):
+    """Test concurrent cancel and remove operations don't cause issues."""
+    active_id = "dl-active"
+    queued_id = "dl-queued"
+    
+    # Setup: One active and one queued download
+    mock_download_manager._download_tasks[active_id] = MagicMock()
+    mock_download_manager._download_tasks[queued_id] = MagicMock()
+    
+    mock_download_manager._active_downloads[active_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 2,
+        'model_version_id': 2,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Perform cancel and remove concurrently
+    import asyncio
+    cancel_task = asyncio.create_task(coordinator.cancel_download(active_id))
+    remove_task = asyncio.create_task(coordinator.remove_queued_download(queued_id))
+    
+    cancel_result, remove_result = await asyncio.gather(cancel_task, remove_task)
+    
+    assert cancel_result['success'] is True
+    assert remove_result['success'] is True
+    
+    # Verify both are removed
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+
+
+async def test_get_active_downloads_empty_after_all_removed(coordinator, mock_download_manager):
+    """Test that get_active_downloads returns empty list when all downloads are removed."""
+    queued_id = "dl-queued"
+    
+    # Setup: One queued download
+    mock_download_manager._download_tasks[queued_id] = MagicMock()
+    mock_download_manager._active_downloads[queued_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove it
+    result = await coordinator.remove_queued_download(queued_id)
+    assert result['success'] is True
+    
+    # Verify get_active_downloads returns empty list
+    downloads_after = await mock_download_manager.get_active_downloads()
+    assert len(downloads_after['downloads']) == 0
+    assert downloads_after['downloads'] == []
+
+
+async def test_cancel_download_removes_from_all_tracking_dicts(coordinator, mock_download_manager):
+    """Test that cancel removes download from all tracking dictionaries."""
+    download_id = "dl-123"
+    
+    # Setup: Add download to all tracking dicts
+    mock_task = MagicMock()
+    mock_pause_event = MagicMock()
+    
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._pause_events[download_id] = mock_pause_event
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'downloading',
+        'progress': 50,
+    }
+    
+    # Cancel the download
+    result = await coordinator.cancel_download(download_id)
+    assert result['success'] is True
+    
+    # Verify removed from all tracking dicts
+    assert download_id not in mock_download_manager._active_downloads
+    assert download_id not in mock_download_manager._download_tasks
+    assert download_id not in mock_download_manager._pause_events
+
+
+async def test_remove_download_removes_from_all_tracking_dicts(coordinator, mock_download_manager):
+    """Test that remove removes download from all tracking dictionaries."""
+    download_id = "dl-queued"
+    
+    # Setup: Add download to all tracking dicts
+    mock_task = MagicMock()
+    mock_pause_event = MagicMock()
+    
+    mock_download_manager._download_tasks[download_id] = mock_task
+    mock_download_manager._pause_events[download_id] = mock_pause_event
+    mock_download_manager._active_downloads[download_id] = {
+        'model_id': 1,
+        'model_version_id': 1,
+        'status': 'queued',
+        'progress': 0,
+    }
+    
+    # Remove the download
+    result = await coordinator.remove_queued_download(download_id)
+    assert result['success'] is True
+    
+    # Verify removed from all tracking dicts
+    assert download_id not in mock_download_manager._active_downloads
+    assert download_id not in mock_download_manager._download_tasks
+    assert download_id not in mock_download_manager._pause_events
+


### PR DESCRIPTION
Added download queue management with support to cancel downloads, minimize the progress bar. Canceling a download will clean up the partial downloaded data.

Auto-refreshes with each finished download to correctly reflect the status in the UI.

Updated translations for all supported locales.
Added tests for new features.

Ref #677