### PR TITLE
Add single-model update checks to context menus

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Civitai-Daten aktualisieren",
+            "checkUpdates": "Updates prüfen",
             "relinkCivitai": "Mit Civitai neu verknüpfen",
             "copySyntax": "LoRA-Syntax kopieren",
             "copyFilename": "Modell-Dateiname kopieren",

--- a/locales/en.json
+++ b/locales/en.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Refresh Civitai Data",
+            "checkUpdates": "Check Updates",
             "relinkCivitai": "Re-link to Civitai",
             "copySyntax": "Copy LoRA Syntax",
             "copyFilename": "Copy Model Filename",

--- a/locales/es.json
+++ b/locales/es.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Actualizar datos de Civitai",
+            "checkUpdates": "Comprobar actualizaciones",
             "relinkCivitai": "Re-vincular a Civitai",
             "copySyntax": "Copiar sintaxis de LoRA",
             "copyFilename": "Copiar nombre de archivo del modelo",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Actualiser les données Civitai",
+            "checkUpdates": "Vérifier les mises à jour",
             "relinkCivitai": "Relier à nouveau à Civitai",
             "copySyntax": "Copier la syntaxe LoRA",
             "copyFilename": "Copier le nom de fichier du modèle",

--- a/locales/he.json
+++ b/locales/he.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "רענן נתוני Civitai",
+            "checkUpdates": "בדוק עדכונים",
             "relinkCivitai": "קשר מחדש ל-Civitai",
             "copySyntax": "העתק תחביר LoRA",
             "copyFilename": "העתק שם קובץ מודל",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Civitaiデータを更新",
+            "checkUpdates": "更新確認",
             "relinkCivitai": "Civitaiに再リンク",
             "copySyntax": "LoRA構文をコピー",
             "copyFilename": "モデルファイル名をコピー",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Civitai 데이터 새로고침",
+            "checkUpdates": "업데이트 확인",
             "relinkCivitai": "Civitai에 다시 연결",
             "copySyntax": "LoRA 문법 복사",
             "copyFilename": "모델 파일명 복사",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "Обновить данные Civitai",
+            "checkUpdates": "Проверить обновления",
             "relinkCivitai": "Пересвязать с Civitai",
             "copySyntax": "Копировать синтаксис LoRA",
             "copyFilename": "Копировать имя файла модели",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "刷新 Civitai 数据",
+            "checkUpdates": "检查更新",
             "relinkCivitai": "重新关联到 Civitai",
             "copySyntax": "复制 LoRA 语法",
             "copyFilename": "复制模型文件名",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -496,6 +496,7 @@
         },
         "contextMenu": {
             "refreshMetadata": "刷新 Civitai 資料",
+            "checkUpdates": "檢查更新",
             "relinkCivitai": "重新連結 Civitai",
             "copySyntax": "複製 LoRA 語法",
             "copyFilename": "複製模型檔名",

--- a/templates/components/context_menu.html
+++ b/templates/components/context_menu.html
@@ -8,6 +8,9 @@
     <div class="context-menu-item" data-action="refresh-metadata">
         <i class="fas fa-sync"></i> <span>{{ t('loras.contextMenu.refreshMetadata') }}</span>
     </div>
+    <div class="context-menu-item" data-action="check-updates">
+        <i class="fas fa-bell"></i> <span>{{ t('loras.contextMenu.checkUpdates') }}</span>
+    </div>
     <div class="context-menu-item" data-action="relink-civitai">
         <i class="fas fa-link"></i> <span>{{ t('loras.contextMenu.relinkCivitai') }}</span>
     </div>


### PR DESCRIPTION
## Summary
- add a Check Updates option to the single-model context menu just below Refresh Civitai Data
- implement shared handling to request update checks for the active card using existing update APIs and reload behavior
- localize the new menu label across available translations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c943cc4788320a47d6c1b547db649)