### PR TITLE
Add auto-organize exclusion settings

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "Download-Pfad-Vorlagen",
             "exampleImages": "Beispielbilder",
             "updateFlags": "Update-Markierungen",
+            "autoOrganize": "Auto-organize",
             "misc": "Verschiedenes",
             "metadataArchive": "Metadaten-Archiv-Datenbank",
             "storageLocation": "Einstellungsort",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "Videos bei Hover automatisch abspielen",
             "autoplayOnHoverHelp": "Video-Vorschauen nur beim Darüberfahren mit der Maus abspielen"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "Anzeige-Dichte",

--- a/locales/en.json
+++ b/locales/en.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "Download Path Templates",
             "exampleImages": "Example Images",
             "updateFlags": "Update Flags",
+            "autoOrganize": "Auto-organize",
             "misc": "Misc.",
             "metadataArchive": "Metadata Archive Database",
             "storageLocation": "Settings Location",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "Autoplay Videos on Hover",
             "autoplayOnHoverHelp": "Only play video previews when hovering over them"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "Display Density",

--- a/locales/es.json
+++ b/locales/es.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "Plantillas de rutas de descarga",
             "exampleImages": "Imágenes de ejemplo",
             "updateFlags": "Indicadores de actualización",
+            "autoOrganize": "Auto-organize",
             "misc": "Varios",
             "metadataArchive": "Base de datos de archivo de metadatos",
             "storageLocation": "Ubicación de ajustes",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "Reproducir videos automáticamente al pasar el ratón",
             "autoplayOnHoverHelp": "Solo reproducir vistas previas de video al pasar el ratón sobre ellas"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "Densidad de visualización",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "Modèles de chemin de téléchargement",
             "exampleImages": "Images d'exemple",
             "updateFlags": "Indicateurs de mise à jour",
+            "autoOrganize": "Auto-organize",
             "misc": "Divers",
             "metadataArchive": "Base de données d'archive des métadonnées",
             "storageLocation": "Emplacement des paramètres",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "Lecture automatique vidéo au survol",
             "autoplayOnHoverHelp": "Lire les aperçus vidéo uniquement lors du survol"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "Densité d'affichage",

--- a/locales/he.json
+++ b/locales/he.json
@@ -231,6 +231,7 @@
             "downloadPathTemplates": "תבניות נתיב הורדה",
             "exampleImages": "תמונות דוגמה",
             "updateFlags": "תגי עדכון",
+            "autoOrganize": "Auto-organize",
             "misc": "שונות",
             "metadataArchive": "מסד נתונים של ארכיון מטא-דאטה",
             "storageLocation": "מיקום ההגדרות",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "נגן וידאו אוטומטית בריחוף",
             "autoplayOnHoverHelp": "נגן תצוגות מקדימות של וידאו רק בעת ריחוף מעליהן"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "צפיפות תצוגה",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "ダウンロードパステンプレート",
             "exampleImages": "例画像",
             "updateFlags": "アップデートフラグ",
+            "autoOrganize": "Auto-organize",
             "misc": "その他",
             "metadataArchive": "メタデータアーカイブデータベース",
             "storageLocation": "設定の場所",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "ホバー時に動画を自動再生",
             "autoplayOnHoverHelp": "動画プレビューはホバー時にのみ再生されます"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "表示密度",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "다운로드 경로 템플릿",
             "exampleImages": "예시 이미지",
             "updateFlags": "업데이트 표시",
+            "autoOrganize": "Auto-organize",
             "misc": "기타",
             "metadataArchive": "메타데이터 아카이브 데이터베이스",
             "storageLocation": "설정 위치",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "호버 시 비디오 자동 재생",
             "autoplayOnHoverHelp": "마우스를 올렸을 때만 비디오 미리보기를 재생합니다"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "표시 밀도",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "Шаблоны путей загрузки",
             "exampleImages": "Примеры изображений",
             "updateFlags": "Метки обновлений",
+            "autoOrganize": "Auto-organize",
             "misc": "Разное",
             "metadataArchive": "Архив метаданных",
             "storageLocation": "Расположение настроек",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "Автовоспроизведение видео при наведении",
             "autoplayOnHoverHelp": "Воспроизводить превью видео только при наведении курсора"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "Плотность отображения",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "下载路径模板",
             "exampleImages": "示例图片",
             "updateFlags": "更新标记",
+            "autoOrganize": "Auto-organize",
             "misc": "其他",
             "metadataArchive": "元数据归档数据库",
             "storageLocation": "设置位置",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "悬停时自动播放视频",
             "autoplayOnHoverHelp": "仅在悬停时播放视频预览"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "显示密度",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -232,6 +232,7 @@
             "downloadPathTemplates": "下載路徑範本",
             "exampleImages": "範例圖片",
             "updateFlags": "更新標記",
+            "autoOrganize": "Auto-organize",
             "misc": "其他",
             "metadataArchive": "中繼資料封存資料庫",
             "storageLocation": "設定位置",
@@ -250,6 +251,15 @@
         "videoSettings": {
             "autoplayOnHover": "滑鼠懸停自動播放影片",
             "autoplayOnHoverHelp": "僅在滑鼠懸停時播放影片預覽"
+        },
+        "autoOrganizeExclusions": {
+            "label": "Auto-organize exclusions",
+            "placeholder": "Example: extras/*, */backups/*; *_temp.safetensors",
+            "help": "Skip moving files that match these wildcard patterns. Separate multiple patterns with commas or semicolons.",
+            "validation": {
+                "noPatterns": "Enter at least one pattern separated by commas or semicolons.",
+                "saveFailed": "Unable to save exclusions: {message}"
+            }
         },
         "layoutSettings": {
             "displayDensity": "顯示密度",

--- a/py/services/use_cases/auto_organize_use_case.py
+++ b/py/services/use_cases/auto_organize_use_case.py
@@ -39,6 +39,7 @@ class AutoOrganizeUseCase:
         *,
         file_paths: Optional[Sequence[str]] = None,
         progress_callback: Optional[ProgressCallback] = None,
+        exclusion_patterns: Optional[Sequence[str]] = None,
     ) -> AutoOrganizeResult:
         """Run the auto-organize routine guarded by a shared lock."""
 
@@ -53,4 +54,5 @@ class AutoOrganizeUseCase:
             return await self._file_service.auto_organize_models(
                 file_paths=list(file_paths) if file_paths is not None else None,
                 progress_callback=progress_callback,
+                exclusion_patterns=exclusion_patterns,
             )

--- a/settings.json.example
+++ b/settings.json.example
@@ -14,5 +14,6 @@
       "C:/path/to/your/embeddings_folder",
       "C:/path/to/another/embeddings_folder"
     ]
-  }
+  },
+  "auto_organize_exclusions": []
 }

--- a/static/js/api/baseModelApi.js
+++ b/static/js/api/baseModelApi.js
@@ -1252,15 +1252,24 @@ export class BaseModelApiClient {
                 
                 // Start the auto-organize operation
                 const endpoint = this.apiConfig.endpoints.autoOrganize;
-                const requestOptions = {
-                    method: filePaths ? 'POST' : 'GET',
-                    headers: filePaths ? { 'Content-Type': 'application/json' } : {}
-                };
-                
+                const exclusionPatterns = (state.global.settings.auto_organize_exclusions || [])
+                    .filter(pattern => typeof pattern === 'string' && pattern.trim())
+                    .map(pattern => pattern.trim());
+
+                const requestBody = {};
                 if (filePaths) {
-                    requestOptions.body = JSON.stringify({ file_paths: filePaths });
+                    requestBody.file_paths = filePaths;
                 }
-                
+                if (exclusionPatterns.length > 0) {
+                    requestBody.exclusion_patterns = exclusionPatterns;
+                }
+
+                const requestOptions = {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                };
+
                 const response = await fetch(endpoint, requestOptions);
                 
                 if (!response.ok) {

--- a/static/js/state/index.js
+++ b/static/js/state/index.js
@@ -34,6 +34,7 @@ const DEFAULT_SETTINGS_BASE = Object.freeze({
     compact_mode: false,
     priority_tags: { ...DEFAULT_PRIORITY_TAG_CONFIG },
     update_flag_strategy: 'same_base',
+    auto_organize_exclusions: [],
 });
 
 export function createDefaultSettings() {

--- a/templates/components/modals/settings_modal.html
+++ b/templates/components/modals/settings_modal.html
@@ -341,6 +341,29 @@
                 </div>
             </div>
 
+            <div class="settings-section">
+                <h3>{{ t('settings.sections.autoOrganize') }}</h3>
+                <div class="setting-item">
+                    <div class="setting-row">
+                        <div class="setting-info">
+                            <label for="autoOrganizeExclusions">{{ t('settings.autoOrganizeExclusions.label') }}</label>
+                        </div>
+                        <div class="setting-control">
+                            <textarea
+                                id="autoOrganizeExclusions"
+                                rows="3"
+                                placeholder="{{ t('settings.autoOrganizeExclusions.placeholder') }}"
+                                onblur="settingsManager.saveAutoOrganizeExclusions()"
+                            ></textarea>
+                        </div>
+                    </div>
+                    <div class="input-help">
+                        {{ t('settings.autoOrganizeExclusions.help') }}
+                    </div>
+                    <div class="settings-input-error-message" id="autoOrganizeExclusionsError"></div>
+                </div>
+            </div>
+
             <!-- Default Path Customization Section -->
             <div class="settings-section">
                 <h3>{{ t('settings.downloadPathTemplates.title') }}</h3>

--- a/tests/routes/test_base_model_routes_smoke.py
+++ b/tests/routes/test_base_model_routes_smoke.py
@@ -540,7 +540,7 @@ def test_auto_organize_progress_returns_latest_snapshot(mock_service):
 
 
 def test_auto_organize_route_emits_progress(mock_service, monkeypatch: pytest.MonkeyPatch):
-    async def fake_auto_organize(self, file_paths=None, progress_callback=None):
+    async def fake_auto_organize(self, file_paths=None, progress_callback=None, exclusion_patterns=None):
         result = AutoOrganizeResult()
         result.total = 1
         result.processed = 1

--- a/tests/services/test_use_cases.py
+++ b/tests/services/test_use_cases.py
@@ -53,10 +53,15 @@ class StubFileService:
         *,
         file_paths: Optional[List[str]] = None,
         progress_callback=None,
+        exclusion_patterns=None,
     ) -> AutoOrganizeResult:
         result = AutoOrganizeResult()
         result.total = len(file_paths or [])
-        self.calls.append({"file_paths": file_paths, "progress_callback": progress_callback})
+        self.calls.append({
+            "file_paths": file_paths,
+            "progress_callback": progress_callback,
+            "exclusion_patterns": exclusion_patterns,
+        })
         return result
 
 
@@ -144,6 +149,7 @@ async def test_auto_organize_use_case_executes_with_lock() -> None:
 
     assert isinstance(result, AutoOrganizeResult)
     assert file_service.calls[0]["file_paths"] == ["model1"]
+    assert file_service.calls[0]["exclusion_patterns"] is None
 
 
 async def test_auto_organize_use_case_rejects_when_running() -> None:


### PR DESCRIPTION
## Summary
- add an auto_organize_exclusions setting with normalized defaults on both backend and frontend
- expose an auto-organize exclusions input in the settings modal with helper text, validation, and locale strings
- send exclusion patterns with auto-organize requests and filter matching files on the backend, updating related tests

## Testing
- python -m pytest tests/services/test_use_cases.py::test_auto_organize_use_case_executes_with_lock tests/routes/test_base_model_routes_smoke.py::test_auto_organize_route_emits_progress

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec7aa9bf883208521577bfe75335c)