### PR TITLE
fix(trigger_word_toggle): missing consumeExistingState after refactor

### DIFF
--- a/web/comfyui/trigger_word_toggle.js
+++ b/web/comfyui/trigger_word_toggle.js
@@ -311,7 +311,7 @@ app.registerExtension({
           });
       } else {
         // If no ',,' delimiter, treat the entire message as one group
-        const existing = existingTagMap[message.trim()];
+        const existing = consumeExistingState(message.trim());
         tagArray = [{
           text: message.trim(),
           // Use existing values if available, otherwise use defaults


### PR DESCRIPTION
You missed a consumeExistingState in your refactor. So loras with a single keyword did not replace the existing keywords.