### PR TITLE
Fix: Escape HTML in Prompt/NegativePrompt for MetadataPanel

### DIFF
--- a/static/js/components/shared/showcase/MetadataPanel.js
+++ b/static/js/components/shared/showcase/MetadataPanel.js
@@ -2,6 +2,7 @@
  * MetadataPanel.js
  * Generates metadata panels for showcase media items
  */
+import { escapeHtml } from '../utils.js';
 
 /**
  * Generate metadata panel HTML
@@ -49,6 +50,7 @@ export function generateMetadataPanel(hasParams, hasPrompts, prompt, negativePro
     }
     
     if (prompt) {
+        prompt = escapeHtml(prompt);
         content += `
             <div class="metadata-row prompt-row">
                 <span class="metadata-label">Prompt:</span>
@@ -64,6 +66,7 @@ export function generateMetadataPanel(hasParams, hasPrompts, prompt, negativePro
     }
     
     if (negativePrompt) {
+        negativePrompt = escapeHtml(negativePrompt);
         content += `
             <div class="metadata-row prompt-row">
                 <span class="metadata-label">Negative Prompt:</span>


### PR DESCRIPTION
* Fixed a bug where `prompt` and `negativePrompt` were both being added directly to HTML without escaping them. Given prompts are allowed to have HTML characters (e.g. `<lora:something:0.75>`), by forgetting to escape them some tags were missing in the metadata views for example images using those characters.