### PR TITLE
Handle Enter on tag input to add tags and add unit tests

### DIFF
--- a/static/js/managers/import/RecipeDataManager.js
+++ b/static/js/managers/import/RecipeDataManager.js
@@ -17,6 +17,10 @@ export class RecipeDataManager {
                 return;
             }
 
+            if (event.isComposing || event.keyCode === 229) {
+                return;
+            }
+
             event.preventDefault();
             this.addTag();
         });

--- a/tests/frontend/managers/RecipeDataManager.tagInput.test.js
+++ b/tests/frontend/managers/RecipeDataManager.tagInput.test.js
@@ -53,4 +53,54 @@ describe('RecipeDataManager tag input Enter behavior', () => {
 
     expect(importManager.recipeTags).toEqual(['anime']);
   });
+
+  it('ignores Enter while IME composition is active', async () => {
+    const { RecipeDataManager } = await import('../../../static/js/managers/import/RecipeDataManager.js');
+    const importManager = {
+      recipeTags: [],
+      stepManager: { showStep: vi.fn() },
+    };
+    const manager = new RecipeDataManager(importManager);
+
+    manager.setupTagInputEnterHandler();
+
+    const tagInput = document.getElementById('tagInput');
+    tagInput.value = '未確定';
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'isComposing', { value: true });
+    tagInput.dispatchEvent(event);
+
+    expect(importManager.recipeTags).toEqual([]);
+    expect(tagInput.value).toBe('未確定');
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores keyCode 229 fallback during composition', async () => {
+    const { RecipeDataManager } = await import('../../../static/js/managers/import/RecipeDataManager.js');
+    const importManager = {
+      recipeTags: [],
+      stepManager: { showStep: vi.fn() },
+    };
+    const manager = new RecipeDataManager(importManager);
+
+    manager.setupTagInputEnterHandler();
+
+    const tagInput = document.getElementById('tagInput');
+    tagInput.value = '候補';
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'keyCode', { value: 229 });
+    tagInput.dispatchEvent(event);
+
+    expect(importManager.recipeTags).toEqual([]);
+    expect(tagInput.value).toBe('候補');
+    expect(event.defaultPrevented).toBe(false);
+  });
 });


### PR DESCRIPTION
### Motivation
- Improve UX by allowing users to add tags by pressing `Enter` in the tag input instead of only clicking a button. 
- Prevent multiple identical event handlers from being registered when the details step is shown repeatedly. 
- Ensure tag input wiring is established when the details UI is displayed via `showRecipeDetailsStep`.

### Description
- Add `setupTagInputEnterHandler()` to `RecipeDataManager` to attach a `keydown` listener that calls `addTag()` when `Enter` is pressed. 
- Guard handler registration with an element flag `hasEnterAddTagHandler` to avoid duplicate listeners. 
- Call `setupTagInputEnterHandler()` from `showRecipeDetailsStep()` so the handler is set up when the details step is shown. 
- Add frontend unit tests in `tests/frontend/managers/RecipeDataManager.tagInput.test.js` that mock helpers and verify Enter behavior and duplicate-handler prevention. 

### Testing
- Run `vitest` for frontend tests including `tests/frontend/managers/RecipeDataManager.tagInput.test.js`, and the new tests passed. 
- The tests verify that pressing `Enter` adds the tag, clears the input, updates the tags display, and that calling the setup twice does not produce duplicate handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5dac76eb0832097163ef749551708)