### PR TITLE
Use flex gap for header spacing

### DIFF
--- a/static/css/components/header.css
+++ b/static/css/components/header.css
@@ -66,7 +66,6 @@
   display: flex;
   gap: 0.5rem;
   flex-shrink: 0;
-  margin-right: 1rem;
 }
 
 .nav-item {

--- a/static/css/components/header.css
+++ b/static/css/components/header.css
@@ -19,6 +19,7 @@
   align-items: center;
   justify-content: space-between;
   height: 100%;
+  gap: 1rem;
 }
 
 /* Responsive header container for larger screens */
@@ -101,7 +102,6 @@
 .header-search {
   flex: 1;
   max-width: 400px;
-  margin: 0 1rem;
   transition: opacity 0.2s ease;
 }
 


### PR DESCRIPTION
This fixes the spacing between `main-nav` and `header-branding` by removing the horizontal margin around the search bar and setting the gap for the parent `header-container` flex.

Before:
<img width="1258" height="64" alt="image" src="https://github.com/user-attachments/assets/5a8d493d-56e7-4fde-a4bd-53f18cbbfe19" />

After:
<img width="1259" height="59" alt="image" src="https://github.com/user-attachments/assets/b7ee0b9f-6894-47e7-91e8-a90844dcd188" />
