### PR TITLE
fix: commit dragged strength through options.setValue at drag end

### DIFF
--- a/web/comfyui/loras_widget_events.js
+++ b/web/comfyui/loras_widget_events.js
@@ -232,9 +232,13 @@ export function initDrag(
         onDragEnd();
       }
 
-      // Now do the re-render after drag is complete
-      if (renderFunction) {
-        renderFunction(widget.value, widget);
+      // Commit final value through options.setValue so external observers are notified.
+      // During drag, handleStrengthDrag mutates widgetValue in-place (updateWidget=false),
+      // bypassing widget.value setter and options.setValue entirely. This assignment
+      // flushes the in-place mutation through the setter so any setValue wrappers fire.
+      widget.value = widget.value;
+      if (typeof widget.callback === 'function') {
+        widget.callback(widget.value);
       }
     }
   };
@@ -349,11 +353,15 @@ export function initHeaderDrag(headerEl, widget, renderFunction) {
     document.body.classList.remove('lm-lora-strength-dragging');
 
     // Only re-render if we actually dragged
-    if (wasDragging && renderFunction) {
-      renderFunction(widget.value, widget);
+    if (wasDragging) {
+      // Commit final value through options.setValue so external observers are notified.
+      widget.value = widget.value;
+      if (typeof widget.callback === 'function') {
+        widget.callback(widget.value);
+      }
     }
   };
-  
+
   // Handle pointer up to end dragging
   headerEl.addEventListener('pointerup', endDrag);
   


### PR DESCRIPTION
## Problem

When a user drags a LoRA strength slider, the final value is not committed through `options.setValue`. This means any external observer that wraps `options.setValue` (e.g. [ComfyUI Mirror Panel](https://github.com/1756141021/comfyui-mirror-panel)'s bidirectional widget sync) never sees the dragged change and treats the widget as unchanged.

**Root cause** — two-step issue in `loras_widget_events.js`:

1. `handleStrengthDrag` is called with `updateWidget=false` during `pointermove`. This mutates `widgetValue` **in-place** via `parseLoraValue`'s direct array reference, bypassing `widget.value` setter and `options.setValue` entirely.

2. `endDrag` only called `renderFunction(widget.value, widget)` for a DOM refresh after drag. It never called `widget.value = ...`, so `options.setValue` was never triggered.

**Symptom in Mirror Panel**: user drags a slider in the mirror view, runs the workflow, slider reverts to the original value — because `syncRootDataToMirror` (running after execution) compares `mw.value` vs `ow.value`, sees them differ (root still has the old value), and resets the mirror back.

## Fix

Replace the explicit `renderFunction(...)` call at drag end with:

```js
widget.value = widget.value;
if (typeof widget.callback === 'function') {
  widget.callback(widget.value);
}
```

`widget.value = widget.value` flushes the in-place mutation through the setter → `options.setValue` → DOM re-render + observer notification. Also fires `widget.callback` for parity with the `updateWidget=true` path in `handleStrengthDrag`.

Applied the same fix to `initHeaderDrag` (proportional all-LoRA header drag).

## Test

1. Add a LoRA, set strength by dragging the slider
2. Any `options.setValue` wrapper on the widget should now receive the final dragged value
3. Regression: normal drag behaviour (visual feedback, final value) unchanged