### PR TITLE
fix: match local LoRAs by AutoV2 hash when Civitai model is deleted

### DIFF
--- a/py/services/model_hash_index.py
+++ b/py/services/model_hash_index.py
@@ -7,6 +7,7 @@ class ModelHashIndex:
     def __init__(self):
         self._hash_to_path: Dict[str, str] = {}
         self._filename_to_hash: Dict[str, str] = {}
+        self._autov2_to_path: Dict[str, str] = {}
         # New data structures for tracking duplicates
         self._duplicate_hashes: Dict[str, List[str]] = {}  # sha256 -> list of paths
         self._duplicate_filenames: Dict[str, List[str]] = {}  # filename -> list of paths
@@ -63,6 +64,9 @@ class ModelHashIndex:
         # Add new mappings
         self._hash_to_path[sha256] = file_path
         self._filename_to_hash[filename] = sha256
+        # AutoV2 = first 10 chars of SHA256
+        if len(sha256) >= 10:
+            self._autov2_to_path[sha256[:10]] = file_path
     
     def _get_filename_from_path(self, file_path: str) -> str:
         """Extract filename without extension from path"""
@@ -157,7 +161,12 @@ class ModelHashIndex:
                 del self._duplicate_filenames[filename]
                 if filename in self._filename_to_hash:
                     del self._filename_to_hash[filename]
-    
+
+        # Remove from AutoV2 index
+        autov2_keys_to_remove = [k for k, v in self._autov2_to_path.items() if v == file_path]
+        for k in autov2_keys_to_remove:
+            del self._autov2_to_path[k]
+
     def remove_by_hash(self, sha256: str) -> None:
         """Remove entry by hash"""
         sha256 = sha256.lower()
@@ -195,13 +204,24 @@ class ModelHashIndex:
                     # If only one entry remains, it's no longer a duplicate
                     del self._duplicate_filenames[fname]
     
-    def has_hash(self, sha256: str) -> bool:
-        """Check if hash exists in index"""
-        return sha256.lower() in self._hash_to_path
-    
-    def get_path(self, sha256: str) -> Optional[str]:
-        """Get file path for a hash"""
-        return self._hash_to_path.get(sha256.lower())
+    def has_hash(self, hash_value: str) -> bool:
+        """Check if hash exists in index (SHA256 or AutoV2)"""
+        normalized = hash_value.lower()
+        if normalized in self._hash_to_path:
+            return True
+        if len(normalized) == 10:
+            return normalized in self._autov2_to_path
+        return False
+
+    def get_path(self, hash_value: str) -> Optional[str]:
+        """Get file path for a hash (SHA256 or AutoV2)"""
+        normalized = hash_value.lower()
+        path = self._hash_to_path.get(normalized)
+        if path is not None:
+            return path
+        if len(normalized) == 10:
+            return self._autov2_to_path.get(normalized)
+        return None
     
     def get_hash(self, file_path: str) -> Optional[str]:
         """Get hash for a file path"""
@@ -218,6 +238,7 @@ class ModelHashIndex:
         """Clear all entries"""
         self._hash_to_path.clear()
         self._filename_to_hash.clear()
+        self._autov2_to_path.clear()
         self._duplicate_hashes.clear()
         self._duplicate_filenames.clear()
     


### PR DESCRIPTION
## Problem / 问题

Two issues when a LoRA has been **deleted from Civitai** but exists locally:

1. **Display**: Recipe imports from image metadata store LoRA hashes in **AutoV2 format** (10-char short hash). When the Civitai API can't resolve them to SHA256 (model deleted / API offline), the local hash index fails to match — the LoRA shows as missing even though it exists locally.

2. **Syntax generation**: `get_recipe_syntax_tokens()` unconditionally skips all LoRAs with `isDeleted=True`, even when the file is available locally.

两个问题，当 LoRA 已从 Civitai 删除但本地存在时：

1. **显示**：图片元数据中的 LoRA hash 是 AutoV2 格式（10 位短 hash）。Civitai API 无法将其解析为 SHA256（模型已删除/API 离线）时，本地索引匹配失败——即使本地有该文件也显示为未找到。

2. **语法生成**：`get_recipe_syntax_tokens()` 无条件跳过所有 `isDeleted=True` 的 LoRA，即使本地有文件也不发送。

## Solution / 解决方案

### Commit 1: AutoV2 hash matching

AutoV2 is simply `SHA256[:10]`. Added a parallel `_autov2_to_path` index inside `ModelHashIndex`, automatically derived when `add_entry()` is called. `has_hash()` and `get_path()` transparently fall back to AutoV2 for 10-char hashes. No extra file I/O, no schema migration.

AutoV2 就是 `SHA256[:10]`。在 `ModelHashIndex` 中新增 `_autov2_to_path` 索引，`add_entry()` 时自动派生。`has_hash()` 和 `get_path()` 对 10 位 hash 自动回退。无需额外文件读取，无需数据库迁移。

### Commit 2: Recipe syntax for deleted LoRAs

`get_recipe_syntax_tokens()` now tries to resolve the file locally first (via hash index or modelVersionId); only skips if the LoRA is truly unavailable.

`get_recipe_syntax_tokens()` 现在先尝试本地解析（通过 hash 索引或 modelVersionId），仅在确实找不到文件时才跳过。

## Changes / 改动

| File | Change |
|------|--------|
| `py/services/model_hash_index.py` | Added `_autov2_to_path` index; `has_hash()`/`get_path()` support AutoV2 fallback |
| `py/services/recipe_scanner.py` | `get_recipe_syntax_tokens()`: resolve locally before skipping deleted LoRAs |

## Verified / 已验证

- `SHA256[:10]` matches A1111's AutoV2 output on real LoRA files ✓
- Recipes with deleted Civitai LoRAs correctly show "In Library" ✓
- Deleted LoRAs with local files are included in recipe syntax ✓
- Deleted LoRAs without local files are still skipped ✓
- Existing SHA256 matching unaffected ✓
- Already-imported recipes auto-update on next view (no re-import needed) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)