### PR TITLE
fix: include locally available LoRAs in recipe syntax even if deleted from Civitai

### DIFF
--- a/py/services/recipe_scanner.py
+++ b/py/services/recipe_scanner.py
@@ -2513,9 +2513,6 @@ class RecipeScanner:
 
         syntax_parts: List[str] = []
         for lora in loras:
-            if lora.get("isDeleted", False):
-                continue
-
             file_name = None
             folder = ""
             hash_value = (lora.get("hash") or "").lower()
@@ -2550,6 +2547,8 @@ class RecipeScanner:
                         break
 
             if not file_name:
+                if lora.get("isDeleted", False):
+                    continue
                 file_name = lora.get("file_name", "unknown-lora")
                 folder = lora.get("folder", "")
 


### PR DESCRIPTION
## Problem / 问题

`get_recipe_syntax_tokens()` unconditionally skips all LoRAs with `isDeleted=True`. This means when a user applies a recipe, LoRAs deleted from Civitai are never included in the workflow — even if the file exists locally and is correctly detected by the hash index (including the AutoV2 matching from #946).

`get_recipe_syntax_tokens()` 无条件跳过所有 `isDeleted=True` 的 LoRA。这导致用户应用 recipe 时，从 Civitai 删除的 LoRA 不会被包含在工作流中——即使本地有该文件且已被 hash 索引正确识别（包括 #946 的 AutoV2 匹配）。

## Solution / 解决方案

Move the `isDeleted` check **after** local file resolution. The function now tries to find the LoRA locally first (via hash index or modelVersionId); only skips if the file is truly unavailable.

将 `isDeleted` 检查移到本地文件解析**之后**。函数现在先尝试本地查找（通过 hash 索引或 modelVersionId），仅在确实找不到文件时才跳过。

## Changes / 改动

Only `py/services/recipe_scanner.py` — 2 lines added, 3 removed.

仅修改 `py/services/recipe_scanner.py` — 增 2 行，删 3 行。

**Before / 之前:**
```python
for lora in loras:
    if lora.get("isDeleted", False):
        continue          # ← skips immediately, never checks local
    file_name = ...
```

**After / 之后:**
```python
for lora in loras:
    file_name = ...       # ← try local resolution first
    if not file_name:
        if lora.get("isDeleted", False):
            continue      # ← only skip if truly unavailable
```

## Verified / 已验证

- Deleted LoRAs with local files → included in recipe syntax ✓
- Deleted LoRAs without local files → still skipped ✓
- Non-deleted LoRAs → unaffected ✓

This is a companion fix to #946.

