### PR TITLE
fix: support SOCKS proxies for outbound requests

### DIFF
--- a/py/services/downloader.py
+++ b/py/services/downloader.py
@@ -256,7 +256,9 @@ class Downloader:
                 self._session = None
 
         # Check for app-level proxy settings
-        proxy_url = None
+        proxy_url = None  # http(s) proxy, passed via the per-request `proxy=` kwarg
+        socks_proxy_url = None  # SOCKS proxy, handled via aiohttp-socks connector
+        app_proxy_active = False
         settings_manager = get_settings_manager()
         if settings_manager.get("proxy_enabled", False):
             proxy_host = settings_manager.get("proxy_host", "").strip()
@@ -268,9 +270,19 @@ class Downloader:
             if proxy_host and proxy_port:
                 # Build proxy URL
                 if proxy_username and proxy_password:
-                    proxy_url = f"{proxy_type}://{proxy_username}:{proxy_password}@{proxy_host}:{proxy_port}"
+                    full_proxy_url = f"{proxy_type}://{proxy_username}:{proxy_password}@{proxy_host}:{proxy_port}"
                 else:
-                    proxy_url = f"{proxy_type}://{proxy_host}:{proxy_port}"
+                    full_proxy_url = f"{proxy_type}://{proxy_host}:{proxy_port}"
+
+                app_proxy_active = True
+                # aiohttp cannot tunnel SOCKS via the per-request `proxy=` kwarg
+                # (it would send HTTP to the SOCKS port and fail parsing the
+                # SOCKS handshake reply). SOCKS must be handled by an
+                # aiohttp-socks ProxyConnector instead.
+                if proxy_type.startswith("socks"):
+                    socks_proxy_url = full_proxy_url
+                else:
+                    proxy_url = full_proxy_url
 
                 logger.debug(
                     f"Using app-level proxy: {proxy_type}://{proxy_host}:{proxy_port}"
@@ -294,13 +306,27 @@ class Downloader:
             logger.debug("SSL: certifi unavailable; using system default CA bundle")
 
         # Optimize TCP connection parameters
-        connector = aiohttp.TCPConnector(
+        connector_kwargs = dict(
             ssl=ssl_context,
             limit=8,  # Concurrent connections
             ttl_dns_cache=300,  # DNS cache timeout
             force_close=False,  # Keep connections for reuse
             enable_cleanup_closed=True,
         )
+        if socks_proxy_url:
+            # Route all traffic through the SOCKS proxy via aiohttp-socks. The
+            # connector tunnels every connection, so no per-request `proxy=` is
+            # used (and must not be — see self._proxy_url below).
+            try:
+                from aiohttp_socks import ProxyConnector
+            except ImportError as e:  # pragma: no cover
+                raise RuntimeError(
+                    "A SOCKS proxy is configured but the 'aiohttp-socks' package "
+                    "is not installed. Install it with: pip install aiohttp-socks"
+                ) from e
+            connector = ProxyConnector.from_url(socks_proxy_url, **connector_kwargs)
+        else:
+            connector = aiohttp.TCPConnector(**connector_kwargs)
 
         # Configure timeout parameters
         timeout = aiohttp.ClientTimeout(
@@ -311,12 +337,14 @@ class Downloader:
 
         self._session = aiohttp.ClientSession(
             connector=connector,
-            trust_env=proxy_url
-            is None,  # Only use system proxy if no app-level proxy is set
+            # Only fall back to system/env proxy when no app-level proxy is active
+            trust_env=not app_proxy_active,
             timeout=timeout,
         )
 
-        # Store proxy URL for use in requests
+        # Store proxy URL for per-request use. Stays None for SOCKS because the
+        # ProxyConnector already tunnels everything; passing proxy= for SOCKS
+        # would re-trigger the original aiohttp parse error.
         self._proxy_url = proxy_url
         self._session_created_at = datetime.now()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+aiohttp-socks
 jinja2
 safetensors
 piexif


### PR DESCRIPTION
## Problem

Selecting a **SOCKS** proxy type in Settings does not work for any outbound request. Requests fail with:

```
Error making GET request to https://civitai.com/api/v1/models: 400,
message="Bad status line:\n  Expected HTTP/, RTSP/ or ICE/:\n\n  b'\x05\xff'\n    ^",
url='socks5://<host>:1080'
```

### Root cause

`py/services/downloader.py` builds the proxy URL (e.g. `socks5://host:port`) and passes it to aiohttp's per-request `proxy=` argument:

```python
proxy_url = f"{proxy_type}://{proxy_host}:{proxy_port}"
...
session.request(method, url, proxy=self.proxy_url)
```

aiohttp's `proxy=` argument **only supports `http(s)://` proxies** — it cannot tunnel SOCKS. With a SOCKS proxy aiohttp opens a plain TCP connection to the proxy port and writes an HTTP request; the SOCKS5 server replies with its method-selection handshake bytes (`\x05\xff` = version 5, "no acceptable auth methods"), and aiohttp raises "Bad status line" trying to parse that as an HTTP status line. So `http`/`https` proxy types work, but every `socks*` type is broken.

## Fix

Route SOCKS proxy types through an [`aiohttp_socks.ProxyConnector`](https://github.com/romis2012/aiohttp-socks) on the session (the supported way to do SOCKS with aiohttp), and keep the `proxy=` kwarg path for `http(s)` proxies only:

- `proxy_type.startswith("socks")` → build the session with `ProxyConnector.from_url(...)`; `self._proxy_url` stays `None` so per-request code never re-sets `proxy=` (which would re-trigger the parse error).
- `http`/`https` → unchanged (`TCPConnector` + per-request `proxy=`).
- `trust_env` now keys off an `app_proxy_active` flag instead of `proxy_url is None`, so the env-proxy fallback is still suppressed when a SOCKS proxy is configured.
- A clear `RuntimeError` is raised if a SOCKS proxy is configured but `aiohttp-socks` is missing.
- Adds `aiohttp-socks` to `requirements.txt`.

All existing request sites (`download_file`, `download_to_memory`, `get_response_headers`, `make_request`, and the aria2 redirect-resolver) flow through this session, so they all gain SOCKS support with no further changes.

## Testing

Verified against a live `socks5://` proxy:

```python
from aiohttp_socks import ProxyConnector
conn = ProxyConnector.from_url("socks5://<host>:1080")
async with aiohttp.ClientSession(connector=conn) as s:
    async with s.get("https://civitai.com/api/v1/models?limit=1") as r:
        print(r.status)  # 200
```

Before the change the same request fails with the "Bad status line" error above; after it, Civitai returns `200`.

## Note (out of scope)

The external **aria2c** downloader path is unaffected by this change and still does not receive any proxy (aria2 also doesn't support SOCKS proxies). Mentioning for awareness — happy to follow up separately if proxying aria2's HTTP downloads is desired.
