### PR TITLE
fix(filters): prevent search query from being persisted in localStorage

### DIFF
--- a/static/js/managers/FilterManager.js
+++ b/static/js/managers/FilterManager.js
@@ -729,10 +729,12 @@ export class FilterManager {
         const pageState = getCurrentPageState();
         const storageKey = `${this.currentPage}_filters`;
 
-        // Save filters to localStorage (exclude EMPTY_WILDCARD_MARKER)
+        // Save filters to localStorage (exclude EMPTY_WILDCARD_MARKER and transient search)
         const filtersSnapshot = this.cloneFilters();
         // Don't persist EMPTY_WILDCARD_MARKER - it's a runtime-only marker
         filtersSnapshot.baseModel = filtersSnapshot.baseModel.filter(m => m !== EMPTY_WILDCARD_MARKER);
+        // Don't persist search - it's transient and managed by SearchManager
+        delete filtersSnapshot.search;
         setStorageItem(storageKey, filtersSnapshot);
 
         // Update state with current filters
@@ -993,7 +995,7 @@ export class FilterManager {
             license: { ...(this.filters.license || {}) },
             modelTypes: [...(this.filters.modelTypes || [])],
             tagLogic: this.filters.tagLogic || 'any',
-            search: this.filters.search || pageState?.filters?.search || ''
+            search: pageState?.filters?.search ?? ''
         };
     }
 


### PR DESCRIPTION
## Problem

When a filter condition was changed while the search box contained a query, the search value was saved into `localStorage` (`lora_manager_*_filters`) along with other filter state. This caused two issues:

1. The persisted search value was never updated by subsequent search box input (since SearchManager only updates `pageState.filters.search`, not `FilterManager.filters.search`), so the stale value was permanently restored on every page load.
2. The stale search could not be cleared by refreshing, restarting the backend, or typing a new query — only by manually clearing browser site data.

## Root Cause

- `applyFilters()` persisted the full `cloneFilters()` snapshot (including `search`) to localStorage.
- `cloneFilters()` used `this.filters.search || pageState?.filters?.search`, where `this.filters.search` (loaded from localStorage) was always truthy and short-circuited the fallback to the live value.

## Fix

- Exclude `search` from the localStorage snapshot in `applyFilters()` — search is transient state managed by SearchManager and should not survive page reloads.
- Simplify `cloneFilters()` to read search exclusively from `pageState?.filters?.search` (the single source of truth maintained by SearchManager).

## Testing

- Enter a search query → change a filter → verify results combine both conditions.
- Refresh the page → search box is empty, filters are restored.
- Change search query → change a filter → verify the *current* query is used, not a stale one.