### PR TITLE
fix(SaveImageLM): resolve %NodeTitle.WidgetName% placeholders from the prompt graph

### DIFF
--- a/docs/dom_widget_dev_guide.md
+++ b/docs/dom_widget_dev_guide.md
@@ -242,6 +242,37 @@ inputEl.addEventListener("change", () => {
 
 > **⚠️ Important**: For Vue-based DOM widgets with text inputs, follow the [Value Persistence Best Practices](dom-widgets/value-persistence-best-practices.md) to avoid sync issues. Key takeaway: use DOM element as single source of truth, avoid internal state variables and v-model.
 
+#### `serializeValue` does not reach the backend for input-backed widgets
+
+Do not use `widget.serializeValue` to transform a value on its way to the Python
+node. `graphToPrompt` (verified in frontend `1.47.12`) builds each node's inputs
+in two passes:
+
+```javascript
+for (const [i, w] of widgets.entries())        // pass 1
+  inputs[w.name] = w.serializeValue ? await w.serializeValue(node, i) : w.value
+for (const [i, slot] of node.inputs.entries()) {  // pass 2
+  const resolved = node.resolveInput(i)
+  if (resolved?.widgetInfo) { inputs[slot.name] = resolved.widgetInfo.value; continue }  // clobbers pass 1
+  inputs[slot.name] = [String(resolved.origin_id), parseInt(resolved.origin_slot)]
+}
+```
+
+Any widget that also exists as a node input (i.e. every standard `INPUT_TYPES`
+widget) gets its serialized value overwritten with the **raw** widget value.
+`serializeValue` still works for workflow persistence, just not for the prompt.
+ComfyUI's own `Comfy.SaveImageExtraOutput` extension is affected by this too, so
+it is an upstream behavior, not something a custom node can hook around.
+
+**Do this instead**: transform the value backend-side, using the `PROMPT` hidden
+input to read other nodes' widget values. See
+`SaveImageLM._resolve_cross_node_placeholders` in `py/nodes/save_image.py`.
+
+**Removed — don't reintroduce**: the `applyTextReplacements` / `formatDate` /
+`serializeValue` layer in `web/comfyui/save_image_extra_output.js`. It resolved
+`%NodeTitle.WidgetName%` filename placeholders in the frontend and silently
+stopped reaching the backend.
+
 ### 5.3 The Restoration Mechanism (`configure`)
 
 *   **`configure(data)`**: When a Workflow is loaded, `LGraphNode` calls its `configure(data)` method.

--- a/py/nodes/save_image.py
+++ b/py/nodes/save_image.py
@@ -591,6 +591,91 @@ class SaveImageLM:
         return filename
 
     @staticmethod
+    def _sanitize_filename_value(value) -> str:
+        # '%' is stripped too: a resolved value must not introduce new pattern
+        # segments for the format_filename pass that runs after resolution.
+        text = str(value)
+        return re.sub(r'[/?<>\\:*|"%\x00-\x1F\x7F]', "_", text)
+
+    def _lookup_node_widget_value(self, prompt, node_title, widget_name):
+        """Resolve a widget value from the workflow prompt graph.
+
+        Matches a node by `_meta` title first; if no titled node supplies the
+        widget, falls back to a class_type match. Returns None when nothing
+        usable is found.
+        """
+        if not isinstance(prompt, dict):
+            return None
+
+        fallback = None
+        for node_data in prompt.values():
+            if not isinstance(node_data, dict):
+                continue
+            meta = node_data.get("_meta")
+            title_match = isinstance(meta, dict) and meta.get("title") == node_title
+            class_match = node_data.get("class_type") == node_title
+            if not title_match and not class_match:
+                continue
+
+            inputs = node_data.get("inputs")
+            if not isinstance(inputs, dict):
+                continue
+            value = inputs.get(widget_name)
+            if value is None:
+                continue
+            # Linked inputs arrive as [origin_node, origin_slot]; cannot resolve statically.
+            if isinstance(value, (list, tuple)) and len(value) == 2:
+                continue
+
+            if title_match:
+                return self._sanitize_filename_value(value)
+            if fallback is None:
+                fallback = self._sanitize_filename_value(value)
+
+        return fallback
+
+    def _resolve_cross_node_placeholders(self, filename_prefix, prompt):
+        """Resolve %NodeTitle.WidgetName% placeholders from the prompt graph.
+
+        ComfyUI's graphToPrompt serializes every widget via serializeValue, then
+        overwrites each widget-backed input with the raw widget value on a second
+        pass (confirmed in frontend 1.47.12). The frontend hook that used to live
+        in save_image_extra_output.js therefore never reaches the backend, so
+        resolution happens here against the `prompt` data instead.
+
+        Unresolvable tokens are left untouched so they stay visible in the saved
+        filename rather than silently collapsing to an empty string.
+        """
+        if not filename_prefix or "%" not in filename_prefix:
+            return filename_prefix
+
+        try:
+            for segment in re.findall(self.pattern_format, filename_prefix):
+                parts = segment.replace("%", "").split(".")
+                if len(parts) != 2:
+                    continue
+                node_title, widget_name = parts
+                value = self._lookup_node_widget_value(prompt, node_title, widget_name)
+                if value is None:
+                    logger.warning(
+                        "SaveImageLM: could not resolve filename placeholder %s "
+                        "(no node titled/typed '%s' with widget '%s' in the prompt)",
+                        segment,
+                        node_title,
+                        widget_name,
+                    )
+                    continue
+                filename_prefix = filename_prefix.replace(segment, value)
+        except Exception as e:
+            # A malformed prompt graph must never block saving the image.
+            logger.error(
+                f"SaveImageLM: failed to resolve cross-node filename placeholders: {e}",
+                exc_info=True,
+            )
+
+        return filename_prefix
+
+    @staticmethod
     def _get_cached_model_by_name(scanner, name):
         cache = getattr(scanner, "_cache", None)
         if cache is None or not name:
@@ -814,7 +899,10 @@ class SaveImageLM:
 
         metadata = self.format_metadata(metadata_dict, add_loras_to_prompt)
 
-        # Process filename_prefix with pattern substitution
+        # Process filename_prefix with pattern substitution.
+        # Cross-node tokens (%NodeTitle.WidgetName%) are resolved from the prompt
+        # graph first, then generation-metadata patterns are applied.
+        filename_prefix = self._resolve_cross_node_placeholders(filename_prefix, prompt)
         filename_prefix = self.format_filename(filename_prefix, metadata_dict)
 
         # Get initial save path info once for the batch

--- a/tests/nodes/test_save_image.py
+++ b/tests/nodes/test_save_image.py
@@ -517,3 +517,153 @@ def test_png_does_not_pass_webp_method_or_jpeg_subsampling(monkeypatch, tmp_path
 
     assert "method" not in captured
     assert "subsampling" not in captured
+
+
+def _sample_prompt():
+    return {
+        "1": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": {"ckpt_name": "DasiwaIl.safetensors"},
+            "_meta": {"title": "CheckpointLoaderSimple"},
+        },
+        "2": {
+            "class_type": "LoraLoader",
+            "inputs": {"lora_name": "anime_style_v2.safetensors"},
+            "_meta": {"title": "Lora"},
+        },
+    }
+
+
+def test_resolve_cross_node_placeholders_by_title(monkeypatch, tmp_path):
+    _configure_save_paths(monkeypatch, tmp_path)
+    _configure_metadata(monkeypatch, {"prompt": "prompt text", "seed": 123})
+
+    captured_prefix = []
+    monkeypatch.setattr(
+        "folder_paths.get_save_image_path",
+        lambda prefix, *_: captured_prefix.append(prefix) or (str(tmp_path), "sample", 1, "", "sample"),
+        raising=False,
+    )
+
+    node = SaveImageLM()
+    node.save_images(
+        [_make_image()],
+        "samples/%Lora.lora_name%",
+        "png",
+        id="node-1",
+        prompt=_sample_prompt(),
+    )
+
+    assert captured_prefix == ["samples/anime_style_v2.safetensors"]
+
+
+def test_resolve_cross_node_placeholders_falls_back_to_class_type():
+    node = SaveImageLM.__new__(SaveImageLM)
+
+    result = node._resolve_cross_node_placeholders(
+        "%LoraLoader.lora_name%",
+        _sample_prompt(),
+    )
+    assert result == "anime_style_v2.safetensors"
+
+    result = node._resolve_cross_node_placeholders(
+        "%Missing.node%_%Lora.unknown_field%",
+        _sample_prompt(),
+    )
+    assert result == "%Missing.node%_%Lora.unknown_field%"
+
+
+def test_resolve_cross_node_placeholders_sanitizes_and_skips_linked_inputs():
+    node = SaveImageLM.__new__(SaveImageLM)
+    prompt = {
+        "3": {
+            "class_type": "Text",
+            "inputs": {
+                "text": "a/b\\c:d",
+                # Linked inputs carry [origin_node, origin_slot] and must be skipped
+                "linked_text": [1, 2],
+            },
+            "_meta": {"title": "My Text"},
+        }
+    }
+
+    assert node._resolve_cross_node_placeholders("%My Text.text%", prompt) == "a_b_c_d"
+    assert node._resolve_cross_node_placeholders("%My Text.linked_text%", prompt) == (
+        "%My Text.linked_text%"
+    )
+
+
+def test_resolve_cross_node_placeholders_strips_percent_from_value():
+    """A resolved value must not introduce segments for the later format pass."""
+    node = SaveImageLM.__new__(SaveImageLM)
+    prompt = {
+        "3": {
+            "class_type": "Text",
+            "inputs": {"text": "100%seed%done"},
+            "_meta": {"title": "My Text"},
+        }
+    }
+
+    resolved = node._resolve_cross_node_placeholders("%My Text.text%", prompt)
+    assert resolved == "100_seed_done"
+    assert node.format_filename(resolved, {"seed": 123}) == "100_seed_done"
+
+
+def test_resolve_cross_node_placeholders_prefers_title_over_class_type():
+    node = SaveImageLM.__new__(SaveImageLM)
+    prompt = {
+        # Class-type match comes first in graph order but must lose to the title match.
+        "1": {
+            "class_type": "LoraLoader",
+            "inputs": {"lora_name": "by_class.safetensors"},
+            "_meta": {"title": "Style"},
+        },
+        "2": {
+            "class_type": "LoraLoaderModelOnly",
+            "inputs": {"lora_name": "by_title.safetensors"},
+            "_meta": {"title": "LoraLoader"},
+        },
+    }
+
+    assert node._resolve_cross_node_placeholders("%LoraLoader.lora_name%", prompt) == (
+        "by_title.safetensors"
+    )
+
+
+def test_resolve_cross_node_placeholders_survives_malformed_prompt():
+    node = SaveImageLM.__new__(SaveImageLM)
+
+    for prompt in (None, [], "not-a-graph", {"1": "not-a-node"}, {"1": {"inputs": None}}):
+        assert node._resolve_cross_node_placeholders("%Lora.lora_name%", prompt) == (
+            "%Lora.lora_name%"
+        )
+
+
+def test_save_images_tolerates_placeholder_resolution_failure(monkeypatch, tmp_path):
+    """Placeholder resolution must never block the actual save."""
+    _configure_save_paths(monkeypatch, tmp_path)
+    _configure_metadata(monkeypatch, {"prompt": "prompt text", "seed": 123})
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("prompt graph exploded")
+
+    monkeypatch.setattr(SaveImageLM, "_lookup_node_widget_value", _boom)
+
+    captured_prefix = []
+    monkeypatch.setattr(
+        "folder_paths.get_save_image_path",
+        lambda prefix, *_: captured_prefix.append(prefix) or (str(tmp_path), "sample", 1, "", "sample"),
+        raising=False,
+    )
+
+    node = SaveImageLM()
+    result = node.save_images(
+        [_make_image()],
+        "samples/%Lora.lora_name%",
+        "png",
+        id="node-1",
+        prompt=_sample_prompt(),
+    )
+
+    assert captured_prefix == ["samples/%Lora.lora_name%"]
+    assert len(result) == 1

--- a/web/comfyui/save_image_extra_output.js
+++ b/web/comfyui/save_image_extra_output.js
@@ -1,112 +1,5 @@
 import { app } from "../../scripts/app.js";
-import { chainCallback, getAllGraphNodes, getWidgetByName } from "./utils.js";
-
-/**
- * Format a date string using the given pattern (e.g. "yyyy-MM-dd").
- * Supports: yyyy, yy, MM, M, dd, d, hh, h, mm, m, ss, s
- */
-function formatDate(text, date) {
-  const pad = (n, len) => n.toString().padStart(len, "0");
-  // Order matters: longer patterns first to avoid partial substring matches.
-  // The original ComfyUI frontend uses the same ordered-alternation approach.
-  return text
-    .replace(/yyyy/g, () => date.getFullYear().toString())
-    .replace(/yy/g, () => pad(date.getFullYear() % 100, 2))
-    .replace(/MM/g, () => pad(date.getMonth() + 1, 2))
-    .replace(/M/g, () => (date.getMonth() + 1).toString())
-    .replace(/dd/g, () => pad(date.getDate(), 2))
-    .replace(/d/g, () => date.getDate().toString())
-    .replace(/hh/g, () => pad(date.getHours(), 2))
-    .replace(/h/g, () => date.getHours().toString())
-    .replace(/mm/g, () => pad(date.getMinutes(), 2))
-    .replace(/m/g, () => date.getMinutes().toString())
-    .replace(/ss/g, () => pad(date.getSeconds(), 2))
-    .replace(/s/g, () => date.getSeconds().toString());
-}
-
-/**
- * Resolve %NodeTitle.WidgetName% placeholders in a string using the current graph.
- *
- * Patterns supported:
- *   %NodeTitle.WidgetName%  – widget value from a node (by title or "Node name for S&R")
- *   %date:format%           – current date/time formatted (e.g. %date:yyyy-MM-dd%)
- *   %width%, %height%       – left as-is, handled by the backend
- *
- * All other %text% patterns are passed through unchanged (they may be handled by
- * the backend's format_filename, e.g. %seed%, %model%, %pprompt%).
- */
-function applyTextReplacements(value) {
-  if (!value || typeof value !== "string" || !value.includes("%")) {
-    return value;
-  }
-
-  // Collect all nodes from the entire graph hierarchy (including subgraphs)
-  const allNodes = getAllGraphNodes(app.graph);
-
-  return value.replace(/%([^%]+)%/g, function (match, text) {
-    const split = text.split(".");
-    if (split.length !== 2) {
-      // Handle %date:format% patterns
-      if (split[0].startsWith("date:")) {
-        return formatDate(split[0].substring(5), new Date());
-      }
-
-      // %width% and %height% are left for the backend to handle
-      if (text !== "width" && text !== "height") {
-        console.warn(
-          "[Save Image (LoraManager)] Unknown placeholder: %" + text + "%"
-        );
-      }
-      return match;
-    }
-
-    // Try finding the node by its "Node name for S&R" property first
-    let nodes = allNodes
-      .filter((n) => n.node.properties?.["Node name for S&R"] === split[0])
-      .map((n) => n.node);
-
-    // Fall back to matching by node title
-    if (!nodes.length) {
-      nodes = allNodes
-        .filter((n) => n.node.title === split[0])
-        .map((n) => n.node);
-    }
-
-    if (!nodes.length) {
-      console.warn(
-        "[Save Image (LoraManager)] Node not found: " + split[0]
-      );
-      return match;
-    }
-
-    if (nodes.length > 1) {
-      console.warn(
-        "[Save Image (LoraManager)] Multiple nodes matched '" +
-          split[0] +
-          "', using first match"
-      );
-    }
-
-    const node = nodes[0];
-    const widget = node.widgets?.find((w) => w.name === split[1]);
-    if (!widget) {
-      console.warn(
-        "[Save Image (LoraManager)] Widget '" +
-          split[1] +
-          "' not found on node " +
-          split[0]
-      );
-      return match;
-    }
-
-    // Sanitize the value: replace characters invalid for filenames
-    // eslint-disable-next-line no-control-regex
-    return ((widget.value ?? "") + "").replaceAll(
-      /[/?<>\\:*|"\x00-\x1F\x7F]/g,
-      "_"
-    );
-  });
-}
+import { chainCallback, getWidgetByName } from "./utils.js";
 
 app.registerExtension({
   name: "LoraManager.SaveImageExtraOutput",
@@ -117,21 +10,7 @@ app.registerExtension({
     }
 
     chainCallback(nodeType.prototype, "onNodeCreated", function () {
-      // Find the filename_prefix widget
-      const widget = getWidgetByName(this, "filename_prefix");
-      if (!widget) {
-        console.warn(
-          "[Save Image (LoraManager)] filename_prefix widget not found"
-        );
-        return;
-      }
-
-      // Override serialization to resolve %NodeTitle.WidgetName% placeholders
-      widget.serializeValue = () => {
-        return applyTextReplacements(widget.value);
-      };
-
-      // --- Conditional widget visibility for webp_method / jpeg_subsampling ---
+      // Conditional widget visibility for webp_method / jpeg_subsampling
       const formatWidget = getWidgetByName(this, "file_format");
       const webpMethodWidget = getWidgetByName(this, "webp_method");
       const jpegSubWidget = getWidgetByName(this, "jpeg_subsampling");


### PR DESCRIPTION
## Why

The `Save Image (LoraManager)` node documents cross-node filename patterns like
`%NodeTitle.WidgetName%` (e.g. `%LoraLoader.lora_name%`) to bake a LoRA name into
saved files. These used to work, then silently stopped — filenames came out with
the literal text `%LoraLoader.lora_name%` left in them.

### Root cause

Resolution lived **only in the frontend**: `web/comfyui/save_image_extra_output.js`
overrode the `filename_prefix` widget's `serializeValue()` to swap
`%NodeTitle.WidgetName%` for the matching node's widget value before the prompt
was sent.

`graphToPrompt` builds each node's inputs in two passes (verified in
`comfyui_frontend_package` 1.47.12):

```js
for (const [i, w] of widgets.entries())            // pass 1
  inputs[w.name] = w.serializeValue ? await w.serializeValue(node, i) : w.value
for (const [i, slot] of node.inputs.entries()) {   // pass 2
  const resolved = node.resolveInput(i)
  if (resolved?.widgetInfo) { inputs[slot.name] = resolved.widgetInfo.value; continue }
  inputs[slot.name] = [String(resolved.origin_id), parseInt(resolved.origin_slot)]
}
```

Pass 2 overwrites every widget-backed input with the **raw** widget value, so the
frontend's resolved string is discarded. The backend's `format_filename()` only
knew flat metadata patterns (`%seed%`, `%model%`, `%date%`, …) and passed the
dotted token through untouched — which is why flat patterns still worked
(`%model:8%` → `DasiwaIl`) while cross-node ones didn't.

This is upstream behavior, not something specific to this node: ComfyUI's own
`Comfy.SaveImageExtraOutput` extension installs the identical hook on `SaveImage`,
`SaveLatent`, etc. and is broken the same way. No custom node can hook around it.

### The fix

Move cross-node placeholder resolution to the **backend**, where it no longer
depends on frontend serialization behavior:

- `save_images()` resolves `%NodeTitle.WidgetName%` tokens from the workflow
  `prompt` graph ComfyUI passes as a hidden input. Nodes are matched by `_meta`
  title first, falling back to `class_type` only if no titled node supplies the
  widget. Linked inputs (`[origin_node, origin_slot]`) are skipped — they have no
  static value.
- Resolved values are sanitized for filename-invalid characters **and `%`**, so a
  widget value containing a percent sign cannot inject a spurious segment into the
  `format_filename()` pass that runs afterwards.
- A malformed prompt graph is logged and skipped rather than failing the save;
  unresolvable tokens are logged with the node/widget name and left visible in the
  filename instead of collapsing to an empty string.
- The dead frontend layer (`applyTextReplacements`, `formatDate`, the
  `serializeValue` hook) is removed from `save_image_extra_output.js`, leaving only
  the conditional `webp_method`/`jpeg_subsampling` visibility logic.

### Behavior changes to be aware of

- **`Node name for S&R` is no longer matched.** The frontend checked that property
  first, then the node title. The prompt graph only carries `_meta.title` and
  `class_type`; `class_type` coincides with the default S&R name but not with an
  edited one. Workflows relying on a *renamed* S&R name need to use the node title
  instead.
- **Single-character `%date:...%` tokens are no longer expanded.** The removed
  `formatDate` supported `M`, `d`, `h`, `m`, `s`; the backend's table only has
  `yyyy/yy/MM/dd/hh/mm/ss`. `%date:yyyy-MM-dd%` is unaffected; `%date:yyyy-M-d%`
  now leaves `M`/`d` literal. Pre-existing backend limitation, newly exposed.
- No canvas/UI behavior changes. `%seed%`, `%model%`, `%width%`, `%height%`,
  `%pprompt%`, `%nprompt%` and two-digit `%date:...%` all keep working through the
  existing backend path.

### Verification

- 29 tests in `tests/nodes/test_save_image.py` pass, covering title lookup,
  title-beats-class-type precedence, class-type fallback, sanitization (including
  `%` stripping), linked-input skipping, malformed-prompt tolerance, resolution
  failure not blocking the save, and the full `save_images()` path.
- The `graphToPrompt` two-pass behavior is documented in
  `docs/dom_widget_dev_guide.md` §5.2 with a "don't reintroduce" note, so the
  frontend hook doesn't come back.
