### PR TITLE
feat(metadata): name-based CivitAI fallback for Draw Things converted checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,54 @@ A comprehensive toolset that streamlines organizing, downloading, and applying L
 
 ![Interface Preview](https://github.com/willmiao/ComfyUI-Lora-Manager/blob/main/static/images/screenshot.png)
 
+## 🚀 Quick Start
+
+### Requirements
+
+- Python 3.10+ (Windows / macOS / Linux)
+- Optional: a CivitAI API key for the download features (add it later in the settings page)
+
+### Standalone Edition (no ComfyUI required)
+
+```bash
+git clone https://github.com/shoomybln/ComfyUI-Lora-Manager.git
+cd ComfyUI-Lora-Manager
+pip install -r requirements.txt
+python standalone.py --port 8188
+```
+
+Then open **http://127.0.0.1:8188/loras** in your browser. On first start the manager creates a default `settings.json` — configure your model folders in the web UI, or edit the file directly:
+
+```json
+{
+  "use_portable_settings": true,
+  "folder_paths": {
+    "loras": ["/path/to/your/loras"],
+    "checkpoints": [],
+    "embeddings": []
+  }
+}
+```
+
+Notes:
+
+- `"use_portable_settings": true` keeps the configuration inside the repository folder instead of your user settings directory
+- Change the port with `python standalone.py --port 9001`
+- On Windows, the portable package also ships with a convenient `run.bat`
+
+### ComfyUI Plugin Mode
+
+1. Install via **ComfyUI Manager** (search for `lora-manager`) or clone this repository into `ComfyUI/custom_nodes/ComfyUI-Lora-Manager`
+2. Restart ComfyUI and click **Launch LoRA Manager** in the ComfyUI menu (or open `http://127.0.0.1:8188/loras`)
+
+## 🎨 Draw Things Integration (this fork)
+
+This fork adds first-class support for [Draw Things](https://drawthings.ai) model libraries:
+
+- Point the **LoRA root** at your Draw Things models folder (`~/Library/Containers/com.liuliu.draw-things/Data/Documents/Models`) — LoRAs stored as converted `<name>_lora_f16.ckpt` files are discovered alongside `.safetensors`
+- Checkpoint scanning supports Draw Things converted checkpoints as well
+- Metadata enrichment tries hash-based CivitAI lookup first and falls back to **name-based lookup** automatically — Draw Things' f16 conversion changes file hashes, so embedded model metadata cannot be used
+
 ## 📺 Tutorial: One-Click LoRA Integration
 Watch this quick tutorial to learn how to use the new one-click LoRA integration feature:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A comprehensive toolset that streamlines organizing, downloading, and applying L
 ### Standalone Edition (no ComfyUI required)
 
 ```bash
-git clone https://github.com/shoomybln/ComfyUI-Lora-Manager.git
+git clone https://github.com/shoomybln/LoRA-Manager-Draw-Things-Remix-ComfyUI-unplugged.git
 cd ComfyUI-Lora-Manager
 pip install -r requirements.txt
 python standalone.py --port 8188

--- a/py/services/civitai_client.py
+++ b/py/services/civitai_client.py
@@ -214,6 +214,104 @@ class CivitaiClient:
             logger.error("API Error: %s", exc)
             return None, str(exc)
 
+    async def get_model_by_name(
+        self,
+        model_name: str,
+        *,
+        model_types: Sequence[str] | None = None,
+        limit: int = 5,
+    ) -> Tuple[Optional[Dict], Optional[str]]:
+        """Look up a model on CivitAI by name, returning a version payload
+        shaped like :meth:`get_model_by_hash`.
+
+        Used as a fallback when a model cannot be found by hash (e.g. Draw
+        Things converted checkpoints whose SHA256 no longer matches the
+        original).  The query is matched against CivitAI's search endpoint;
+        the best matching result whose type is in *model_types* (default:
+        LORA/Checkpoint) is returned with its most relevant version enriched
+        with model-level data (description, tags, license, creator).
+
+        Returns ``(version_dict, None)`` on success or ``(None, reason)``.
+        """
+        if not model_name:
+            return None, "No model name provided"
+
+        search_query = model_name.strip()
+        allowed_types = set(model_types or ("LORA", "Checkpoint"))
+
+        try:
+            success, result = await self._make_request(
+                "GET",
+                f"{self.base_url}/models",
+                use_auth=True,
+                params={
+                    "query": search_query,
+                    "limit": min(max(limit, 1), 20),
+                    "nsfw": "true",
+                },
+            )
+            if not success:
+                return None, str(result)
+
+            items = result.get("items") if isinstance(result, dict) else None
+            if not isinstance(items, list) or not items:
+                return None, "Model not found"
+
+            # Prefer models whose type matches, then the first acceptable one.
+            candidates = [m for m in items if isinstance(m, dict) and m.get("type") in allowed_types]
+            if not candidates:
+                return None, "Model not found"
+
+            # Rank candidates by title similarity to the requested name so we
+            # pick the closest match rather than the first result page entry.
+            def _rank(item: Dict) -> Tuple[int, int]:
+                title = str(item.get("name", "")).lower()
+                target = search_query.lower()
+                if title == target:
+                    return (0, 0)
+                if title in target or target in title:
+                    return (1, 0)
+                return (2, 0)
+
+            candidates.sort(key=_rank)
+            model_data = candidates[0]
+
+            version_entry = None
+            model_versions = model_data.get("modelVersions") or []
+            if model_versions:
+                # Prefer the newest version that has preview images, otherwise
+                # the first version.
+                version_entry = next(
+                    (v for v in model_versions if isinstance(v, dict) and v.get("images")),
+                    None,
+                )
+                if version_entry is None:
+                    version_entry = next(
+                        (v for v in model_versions if isinstance(v, dict)),
+                        None,
+                    )
+
+            if version_entry is None:
+                return None, "Model has no versions"
+
+            version = copy.deepcopy(version_entry)
+            version.pop("index", None)
+            version["modelId"] = model_data.get("id")
+            version["model"] = {
+                "name": model_data.get("name"),
+                "type": model_data.get("type"),
+                "nsfw": model_data.get("nsfw"),
+                "poi": model_data.get("poi"),
+            }
+            self._enrich_version_with_model_data(version, model_data)
+            self._remove_comfy_metadata(version)
+            return version, None
+        except RateLimitError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Error searching model by name '%s': %s", model_name, exc)
+            return None, str(exc)
+
     async def download_preview_image(self, image_url: str, save_path: str):
         try:
             downloader = await get_downloader()

--- a/py/services/civitai_client.py
+++ b/py/services/civitai_client.py
@@ -279,17 +279,23 @@ class CivitaiClient:
             version_entry = None
             model_versions = model_data.get("modelVersions") or []
             if model_versions:
-                # Prefer the newest version that has preview images, otherwise
-                # the first version.
+                # CivitAI returns versions newest-first.  When we fall back to a
+                # name-based match (e.g. Draw Things converted checkpoints whose
+                # SHA256 no longer matches the original), we cannot know which
+                # version the user actually has.  Picking the newest version
+                # would suppress ALL update notifications, because the stored
+                # version_id would equal the latest one on CivitAI.
+                #
+                # Instead, pick the OLDEST version so that every newer version
+                # shows up as an available update.  This is the conservative
+                # choice: it may show an update when none is needed, but it
+                # never hides one.  Preview images are a secondary concern and
+                # can be resolved by the UI from the model's other versions.
+                reversed_versions = [v for v in reversed(model_versions) if isinstance(v, dict)]
                 version_entry = next(
-                    (v for v in model_versions if isinstance(v, dict) and v.get("images")),
+                    (v for v in reversed_versions),
                     None,
                 )
-                if version_entry is None:
-                    version_entry = next(
-                        (v for v in model_versions if isinstance(v, dict)),
-                        None,
-                    )
 
             if version_entry is None:
                 return None, "Model has no versions"

--- a/py/services/lora_scanner.py
+++ b/py/services/lora_scanner.py
@@ -15,8 +15,12 @@ class LoraScanner(ModelScanner):
     """Service for scanning and managing LoRA files"""
     
     def __init__(self):
-        # Define supported file extensions
-        file_extensions = {'.safetensors'}
+        # Define supported file extensions.
+        # `.ckpt` is included so LoRAs exported/converted by Draw Things
+        # (stored as `<name>_lora_f16.ckpt`) are discovered alongside
+        # `.safetensors`. Embedded metadata differs from the safetensors
+        # header, so enrichment relies on hash/name-based CivitAI lookup.
+        file_extensions = {'.safetensors', '.ckpt'}
 
         # Initialize parent class with ModelHashIndex
         from .model_hash_index import ModelHashIndex

--- a/py/services/metadata_sync_service.py
+++ b/py/services/metadata_sync_service.py
@@ -12,7 +12,7 @@ from ..services.settings_manager import SettingsManager
 from ..utils.civitai_utils import resolve_license_payload
 from ..utils.model_utils import determine_base_model
 from ..utils.models import autov3_from_civitai_files
-from .connectivity_guard import OFFLINE_FRIENDLY_MESSAGE, is_expected_offline_error
+from .connectivity_guard import OFFLINE_FRIENDLY_MESSAGE, is_expected_offline_error, is_offline_cooldown_error
 from .errors import RateLimitError
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,37 @@ class MetadataSyncService:
         images = meta.get("images")
         source = meta.get("source")
         return bool(files) and bool(images) and source not in ("archive_db", "civarchive")
+
+    @staticmethod
+    def _is_definitive_name_miss(name_error: Optional[str]) -> bool:
+        """Return True when a failed name search is a definitive "not found".
+
+        A definitive miss means the CivitAI search endpoint responded normally
+        but found no acceptable model. Transient upstream failures (search
+        overload, 5xx, connectivity issues) are NOT definitive — the fallback
+        should remain available for a later retry.
+        """
+        if not name_error:
+            return False
+        normalized = name_error.lower()
+        if "model not found" in normalized or "no model" in normalized:
+            return True
+        if any(
+            keyword in normalized
+            for keyword in (
+                "overloaded",
+                "temporarily",
+                "status 5",
+                "status 503",
+                "timed out",
+                "timeout",
+                "connection refused",
+                "connection reset",
+                "offline",
+            )
+        ):
+            return False
+        return False
 
     async def update_model_metadata(
         self,
@@ -201,6 +232,10 @@ class MetadataSyncService:
             sqlite_attempted = False
 
             if model_data.get("civitai_deleted") is True:
+                name_fallback_pending = (
+                    self._settings.get("civitai_name_fallback", True)
+                    and not model_data.get("name_fallback_checked", False)
+                )
                 if previous_source in (None, "civarchive"):
                     try:
                         provider_attempts.append(("civarchive_api", await self._get_provider("civarchive_api")))
@@ -213,7 +248,7 @@ class MetadataSyncService:
                     except Exception as exc:  # pragma: no cover - provider resolution fault
                         logger.debug("Unable to resolve sqlite provider: %s", exc)
 
-                if not provider_attempts:
+                if not provider_attempts and not name_fallback_pending:
                     if not enable_archive:
                         error_msg = "CivitAI model is deleted and metadata archive DB is not enabled"
                     elif model_data.get("db_checked") is True:
@@ -221,6 +256,12 @@ class MetadataSyncService:
                     else:
                         error_msg = "CivitAI model is deleted and no archive provider is available"
                     return False, error_msg
+
+                # When the name fallback is still pending, allow the flow to
+                # continue past the provider loop so the CivitAI search
+                # endpoint can be consulted before giving up.
+                if not provider_attempts:
+                    provider_attempts.append((None, await self._get_default_provider()))
             else:
                 is_hf_source = bool(model_data.get("hf_url"))
                 if is_hf_source:
@@ -276,6 +317,79 @@ class MetadataSyncService:
 
                 last_error = error or last_error
 
+            # -----------------------------------------------------------------
+            # Name-based fallback
+            #
+            # Some libraries (notably Draw Things converted checkpoints) hash
+            # files differently than the original distribution, so a SHA256
+            # lookup against CivitAI reliably fails even though the model
+            # itself is published there.  When every provider failed to find
+            # the model by hash AND the setting is enabled, fall back to the
+            # CivitAI search endpoint using the model name.
+            # -----------------------------------------------------------------
+            # Track whether the name-based fallback reached a definitive
+            # conclusion. A transient upstream failure (e.g. CivitAI search
+            # being overloaded) must NOT mark the fallback as "already
+            # attempted", otherwise the model can never be recovered later.
+            name_fallback_definitive = False
+            if (
+                civitai_metadata is None
+                and metadata_provider is None
+                and self._settings.get("civitai_name_fallback", True)
+                and not any_rate_limited
+                and not is_offline_cooldown_error(last_error or "")
+                and not model_data.get("name_fallback_checked", False)
+            ):
+                logger.debug(
+                    "Name fallback candidate for %s (rate_limited=%s)",
+                    model_data.get("model_name"),
+                    any_rate_limited,
+                )
+                fallback_provider = await self._get_default_provider()
+                search = getattr(fallback_provider, "get_model_by_name", None)
+                if search is not None:
+                    search_name = model_data.get("model_name") or model_data.get("file_name") or ""
+                    search_name = os.path.splitext(os.path.basename(search_name))[0]
+                    if search_name:
+                        try:
+                            name_metadata, name_error = await search(
+                                search_name,
+                                model_types=("LORA", "Checkpoint"),
+                            )
+                            if name_metadata:
+                                logger.info(
+                                    "Hash lookup failed for %s but matched CivitAI model by name",
+                                    search_name,
+                                )
+                                civitai_metadata = name_metadata
+                                metadata_provider = fallback_provider
+                                provider_used = "civitai_api"
+                                civitai_api_not_found = False
+                                model_data["civitai_deleted"] = False
+                                model_data["from_civitai"] = True
+                            else:
+                                logger.debug(
+                                    "Name fallback failed for %s: %s",
+                                    search_name,
+                                    name_error,
+                                )
+                                name_fallback_definitive = self._is_definitive_name_miss(
+                                    name_error
+                                )
+                                # A transient name-search failure must not
+                                # classify the model as "deleted on CivitAI" —
+                                # the model may exist but the search was merely
+                                # overloaded. Leave it searchable for retries.
+                                if not name_fallback_definitive:
+                                    civitai_api_not_found = False
+                        except RateLimitError:
+                            any_rate_limited = True
+                            logger.warning("Name fallback rate limited for %s", search_name)
+                        except Exception as exc:  # pragma: no cover - defensive logging
+                            logger.error(
+                                "Name fallback error for %s: %s", search_name, exc
+                            )
+
             if civitai_metadata is None or metadata_provider is None:
                 # Track if we need to save metadata
                 needs_save = False
@@ -297,6 +411,20 @@ class MetadataSyncService:
                 # ensure the flags are written to the scanner cache + SQLite.
                 if not needs_save and model_data.get("civitai_deleted") is True:
                     model_data["last_checked_at"] = datetime.now().timestamp()
+                    needs_save = True
+
+                # Remember that the name-based fallback was already attempted so
+                # subsequent refresh cycles do not re-hit the search endpoint.
+                # Only persist this when the fallback reached a definitive
+                # conclusion; a transient upstream error (e.g. search overload)
+                # must leave the fallback available for a later retry.
+                if (
+                    name_fallback_definitive
+                    and not model_data.get("name_fallback_checked")
+                    and not any_rate_limited
+                    and not is_offline_cooldown_error(last_error or "")
+                ):
+                    model_data["name_fallback_checked"] = True
                     needs_save = True
 
                 # Save metadata if any state was updated
@@ -349,6 +477,7 @@ class MetadataSyncService:
                 source = "archive_db"
             model_data["metadata_source"] = source
             model_data["last_checked_at"] = datetime.now().timestamp()
+            model_data["name_fallback_checked"] = True
 
             readable_source = {
                 "civitai_api": "CivitAI API",

--- a/py/services/model_metadata_provider.py
+++ b/py/services/model_metadata_provider.py
@@ -163,6 +163,19 @@ class CivitaiModelMetadataProvider(ModelMetadataProvider):
         
     async def get_model_by_hash(self, model_hash: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
         return await self.client.get_model_by_hash(model_hash)
+
+    async def get_model_by_name(
+        self,
+        model_name: str,
+        *,
+        model_types: Sequence[str] | None = None,
+        limit: int = 5,
+    ) -> Tuple[Optional[Dict], Optional[str]]:
+        """Look up a model by name via the CivitAI search endpoint."""
+        search = getattr(self.client, "get_model_by_name", None)
+        if search is None:
+            return None, "Name search not supported by provider"
+        return await search(model_name, model_types=model_types, limit=limit)
         
     async def get_model_versions(self, model_id: str) -> Optional[Dict[str, Any]]:
         return await self.client.get_model_versions(model_id)
@@ -504,6 +517,40 @@ class FallbackMetadataProvider(ModelMetadataProvider):
                 continue
             except Exception as e:
                 logger.debug("Provider %s failed for get_model_by_hash: %s", label, e)
+                continue
+        return None, "Model not found"
+
+    async def get_model_by_name(
+        self,
+        model_name: str,
+        *,
+        model_types: Sequence[str] | None = None,
+        limit: int = 5,
+    ) -> Tuple[Optional[Dict], Optional[str]]:
+        """Delegate name-based lookup to the first provider that supports it."""
+        for provider, label in self._iter_providers():
+            search = getattr(provider, "get_model_by_name", None)
+            if search is None:
+                continue
+            try:
+                result, error = await self._call_with_rate_limit(
+                    label,
+                    search,
+                    model_name,
+                    model_types=model_types,
+                    limit=limit,
+                )
+                if result:
+                    return result, error
+            except RateLimitError as exc:
+                logger.warning(
+                    "Provider %s is rate-limited (retry_after=%.0fs); skipping to next provider",
+                    label,
+                    exc.retry_after or 0,
+                )
+                continue
+            except Exception as e:
+                logger.debug("Provider %s failed for get_model_by_name: %s", label, e)
                 continue
         return None, "Model not found"
 

--- a/py/services/settings_manager.py
+++ b/py/services/settings_manager.py
@@ -68,6 +68,7 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "enable_metadata_archive_db": False,
     "enable_civarchive_api": True,
     "metadata_provider_order": "civitai_archive_sqlite",
+    "civitai_name_fallback": True,
     "proxy_enabled": False,
     "proxy_host": "",
     "proxy_port": "",

--- a/py/services/use_cases/bulk_metadata_refresh_use_case.py
+++ b/py/services/use_cases/bulk_metadata_refresh_use_case.py
@@ -44,6 +44,7 @@ class BulkMetadataRefreshUseCase:
         total_models = len(cache.raw_data)
 
         enable_metadata_archive_db = self._settings.get("enable_metadata_archive_db", False)
+        enable_name_fallback = self._settings.get("civitai_name_fallback", True)
         skip_paths = self._settings.get("metadata_refresh_skip_paths", [])
         to_process: Sequence[Dict[str, Any]] = [
             model
@@ -56,12 +57,16 @@ class BulkMetadataRefreshUseCase:
             # via the right-click context menu.
             and not model.get("hf_url", "")
             and not (
-                # Skip models confirmed not on CivitAI when no need to retry
+                # Skip models confirmed not on CivitAI when no need to retry.
+                # When the name-based fallback is enabled, models previously
+                # marked civitai_deleted (e.g. Draw Things converted checkpoints
+                # whose hash is unknown to CivitAI) are NOT skipped unless the
+                # name fallback already reached a definitive miss.
                 model.get("from_civitai") is False
                 and model.get("civitai_deleted") is True
                 and (
-                    not enable_metadata_archive_db
-                    or model.get("db_checked", False)
+                    (not enable_metadata_archive_db or model.get("db_checked", False))
+                    and (not enable_name_fallback or model.get("name_fallback_checked", False))
                 )
             )
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,28 @@ def _isolate_settings_dir(tmp_path_factory, monkeypatch, request):
             settings_dir.mkdir(exist_ok=True)
         return str(settings_dir)
 
+    # ``ensure_settings_file()`` checks the *legacy* project-root settings.json
+    # first.  If a developer's real file carries ``use_portable_settings: true``,
+    # it would be returned (and then overwritten / migrated away) by tests.
+    # Redirect the legacy path into the isolated directory so tests can never
+    # touch the real file.  IMPORTANT: this must stay a *dynamic* wrapper that
+    # delegates to the real derivation, because ``get_legacy_settings_path``
+    # follows the (possibly test-patched) ``get_project_root``.  Only the real
+    # repo-root file is redirected; fake roots created by tests keep working.
+    from py.utils import settings_paths as _settings_paths
+
+    _real_get_legacy_settings_path = _settings_paths.get_legacy_settings_path
+
+    def fake_get_legacy_settings_path() -> str:
+        legacy_path = _real_get_legacy_settings_path()
+        if Path(legacy_path).resolve() == (REPO_ROOT / "settings.json").resolve():
+            return str(settings_dir / "settings.json")
+        return legacy_path
+
+    monkeypatch.setattr(
+        "py.utils.settings_paths.get_legacy_settings_path",
+        fake_get_legacy_settings_path,
+    )
     monkeypatch.setattr("py.utils.settings_paths.get_settings_dir", fake_get_settings_dir)
     monkeypatch.setattr(
         "py.utils.settings_paths.user_config_dir",
@@ -129,6 +151,33 @@ def _isolate_settings_dir(tmp_path_factory, monkeypatch, request):
     settings_manager_module.reset_settings_manager()
     yield
     settings_manager_module.reset_settings_manager()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _guard_project_settings_file():
+    """Snapshot the developer's real project settings.json; restore it after the run.
+
+    The project-root settings.json is developer configuration that is not under
+    version control.  Tests must never modify it; if anything slips through the
+    per-test isolation anyway, this guard restores the exact original bytes.
+    """
+
+    from py.utils.settings_paths import get_legacy_settings_path
+
+    real_path = Path(get_legacy_settings_path())
+    original: Optional[bytes] = None
+    existed = real_path.exists()
+    if existed:
+        original = real_path.read_bytes()
+
+    yield
+
+    if original is not None:
+        if not real_path.exists() or real_path.read_bytes() != original:
+            real_path.write_bytes(original)
+    elif real_path.exists():
+        # No file existed before the session; a test must have created one.
+        real_path.unlink()
 
 
 @dataclass

--- a/tests/services/test_civitai_client.py
+++ b/tests/services/test_civitai_client.py
@@ -148,6 +148,114 @@ async def test_get_model_by_hash_propagates_rate_limit(monkeypatch, downloader):
     assert exc_info.value.provider == "civitai_api"
 
 
+async def test_get_model_by_name_matches_and_enriches(monkeypatch, downloader):
+    search_payload = {
+        "items": [
+            {
+                "id": 456,
+                "name": "Anything2Real",
+                "type": "LORA",
+                "nsfw": False,
+                "poi": False,
+                "description": "desc",
+                "tags": ["style"],
+                "creator": {"username": "creator"},
+                "modelVersions": [
+                    {
+                        "id": 789,
+                        "name": "v1.0",
+                        "images": [{"url": "https://example.invalid/p.webp"}],
+                    }
+                ],
+            },
+            {
+                "id": 999,
+                "name": "Unrelated",
+                "type": "LORA",
+                "modelVersions": [{"id": 111, "name": "x", "images": []}],
+            },
+        ]
+    }
+
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        if url.endswith("/models") and kwargs.get("params", {}).get("query") == "anything2real_a":
+            return True, search_payload
+        return False, "unexpected"
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("anything2real_a")
+
+    assert error is None
+    assert result["modelId"] == 456
+    assert result["id"] == 789
+    assert result["model"]["name"] == "Anything2Real"
+    assert result["model"]["description"] == "desc"
+    assert result["model"]["tags"] == ["style"]
+    assert result["images"]  # the version with images was preferred
+
+
+async def test_get_model_by_name_filters_by_type(monkeypatch, downloader):
+    search_payload = {
+        "items": [
+            {
+                "id": 1,
+                "name": "Workflow only",
+                "type": "Workflows",
+                "modelVersions": [{"id": 11, "name": "v1", "images": []}],
+            },
+            {
+                "id": 2,
+                "name": "A LORA",
+                "type": "LORA",
+                "modelVersions": [{"id": 22, "name": "v1", "images": [{}]}],
+            },
+        ]
+    }
+
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        return True, search_payload
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("anything", model_types=("LORA", "Checkpoint"))
+
+    assert error is None
+    assert result["modelId"] == 2
+
+
+async def test_get_model_by_name_not_found(monkeypatch, downloader):
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        return True, {"items": []}
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("missing_model")
+
+    assert result is None
+    assert error == "Model not found"
+
+
+async def test_get_model_by_name_offline_cooldown(downloader):
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        return False, OFFLINE_COOLDOWN_ERROR
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("anything")
+
+    assert result is None
+    assert error == OFFLINE_FRIENDLY_MESSAGE
+
+
 async def test_download_preview_image_writes_file(tmp_path, downloader):
     client = await CivitaiClient.get_instance()
     target = tmp_path / "preview" / "image.jpg"

--- a/tests/services/test_civitai_client.py
+++ b/tests/services/test_civitai_client.py
@@ -197,6 +197,98 @@ async def test_get_model_by_name_matches_and_enriches(monkeypatch, downloader):
     assert result["images"]  # the version with images was preferred
 
 
+async def test_get_model_by_name_prefers_oldest_version_for_update_detection(monkeypatch, downloader):
+    """When the hash-based lookup fails (e.g. Draw Things converted checkpoints),
+    the name fallback cannot know which version the user actually has.  It must
+    pick the OLDEST version so that newer versions still show up as updates.
+    Picking the newest would suppress all update notifications."""
+    # CivitAI returns versions newest-first
+    search_payload = {
+        "items": [
+            {
+                "id": 100,
+                "name": "Test LoRA",
+                "type": "LORA",
+                "modelVersions": [
+                    {
+                        "id": 300,
+                        "name": "v3.0",
+                        "images": [{"url": "https://example.invalid/v3.webp"}],
+                    },
+                    {
+                        "id": 200,
+                        "name": "v2.0",
+                        "images": [{"url": "https://example.invalid/v2.webp"}],
+                    },
+                    {
+                        "id": 100,
+                        "name": "v1.0",
+                        "images": [{"url": "https://example.invalid/v1.webp"}],
+                    },
+                ],
+            },
+        ]
+    }
+
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        return True, search_payload
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("test_lora")
+
+    assert error is None
+    # The OLDEST version (v1.0, id=100) must be selected so that v2.0 and v3.0
+    # are detected as available updates.
+    assert result["id"] == 100
+    assert result["name"] == "v1.0"
+    assert result["modelId"] == 100
+
+
+async def test_get_model_by_name_prefers_oldest_with_images_fallback_to_oldest(monkeypatch, downloader):
+    """If only the newest version has images, we still pick the oldest version
+    (without images) rather than the newest — update detection must not be
+    suppressed."""
+    search_payload = {
+        "items": [
+            {
+                "id": 200,
+                "name": "Test LoRA 2",
+                "type": "LORA",
+                "modelVersions": [
+                    {
+                        "id": 30,
+                        "name": "v3.0",
+                        "images": [{"url": "https://example.invalid/v3.webp"}],
+                    },
+                    {
+                        "id": 10,
+                        "name": "v1.0",
+                        "images": [],
+                    },
+                ],
+            },
+        ]
+    }
+
+    async def fake_make_request(method, url, use_auth=True, **kwargs):
+        return True, search_payload
+
+    downloader.make_request = fake_make_request
+
+    client = await CivitaiClient.get_instance()
+
+    result, error = await client.get_model_by_name("test_lora_2")
+
+    assert error is None
+    # Oldest version (v1.0, id=10) is chosen even though it has no images,
+    # so that v3.0 shows as an available update.
+    assert result["id"] == 10
+    assert result["name"] == "v1.0"
+
+
 async def test_get_model_by_name_filters_by_type(monkeypatch, downloader):
     search_payload = {
         "items": [

--- a/tests/services/test_lora_scanner_ckpt.py
+++ b/tests/services/test_lora_scanner_ckpt.py
@@ -1,0 +1,81 @@
+"""Tests for LoRA scanner discovery of Draw Things converted .ckpt LoRA files."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from py.services import model_scanner
+from py.services.lora_scanner import LoraScanner
+from py.services.model_scanner import ModelScanner
+
+
+def _normalize(path: Path) -> str:
+    return str(path).replace(os.sep, "/")
+
+
+@pytest.fixture(autouse=True)
+def reset_model_scanner_singletons():
+    ModelScanner._instances.clear()
+    ModelScanner._locks.clear()
+    yield
+    ModelScanner._instances.clear()
+    ModelScanner._locks.clear()
+
+
+def _make_loras_root(tmp_path: Path):
+    """Create a loras root containing a .safetensors and a Draw Things style .ckpt file."""
+    loras_root = tmp_path / "loras"
+    loras_root.mkdir()
+
+    safetensors_file = loras_root / "test_lora.safetensors"
+    safetensors_file.write_bytes(b"\x00" * 64)
+
+    # Draw Things names converted LoRAs like `<name>_lora_f16.ckpt`
+    ckpt_file = loras_root / "draw_things_lora_f16.ckpt"
+    ckpt_file.write_bytes(b"\x00" * 64)
+
+    ignored_file = loras_root / "notes.txt"
+    ignored_file.write_text("not a model", encoding="utf-8")
+
+    return loras_root, safetensors_file, ckpt_file, ignored_file
+
+
+@pytest.mark.asyncio
+async def test_lora_scanner_supports_ckpt_extension(tmp_path: Path, monkeypatch):
+    """The LoRA scanner must accept .ckpt alongside .safetensors."""
+    loras_root, _, _, _ = _make_loras_root(tmp_path)
+
+    monkeypatch.setattr(
+        model_scanner.config,
+        "loras_roots",
+        [_normalize(loras_root)],
+        raising=False,
+    )
+
+    scanner = LoraScanner()
+
+    assert scanner.file_extensions == {".safetensors", ".ckpt"}
+
+
+@pytest.mark.asyncio
+async def test_lora_scanner_discovers_ckpt_files(tmp_path: Path, monkeypatch):
+    """Draw Things converted .ckpt LoRAs must be discovered during the scan."""
+    loras_root, safetensors_file, ckpt_file, ignored_file = _make_loras_root(tmp_path)
+
+    monkeypatch.setattr(
+        model_scanner.config,
+        "loras_roots",
+        [_normalize(loras_root)],
+        raising=False,
+    )
+
+    scanner = LoraScanner()
+
+    result = await scanner._gather_model_data()
+
+    discovered = {entry["file_path"] for entry in result.raw_data}
+    assert _normalize(safetensors_file) in discovered, "safetensors file should still be discovered"
+    assert _normalize(ckpt_file) in discovered, "Draw Things .ckpt LoRA should be discovered"
+    assert len(result.raw_data) == 2, "unsupported extensions (.txt) must stay ignored"
+    assert all(not path.endswith(ignored_file.suffix) for path in discovered)

--- a/tests/services/test_metadata_sync_service.py
+++ b/tests/services/test_metadata_sync_service.py
@@ -336,7 +336,9 @@ async def test_fetch_and_update_model_returns_friendly_offline_message(tmp_path)
 
 @pytest.mark.asyncio
 async def test_fetch_and_update_model_respects_deleted_without_archive():
-    helpers = build_service(settings_values={"enable_metadata_archive_db": False})
+    helpers = build_service(
+        settings_values={"enable_metadata_archive_db": False, "civitai_name_fallback": False}
+    )
 
     model_data = {
         "civitai_deleted": True,
@@ -687,3 +689,206 @@ async def test_fetch_and_update_model_does_not_overwrite_api_metadata_with_archi
     
     helpers.metadata_manager.save_metadata.assert_awaited()
     update_cache.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_update_model_name_fallback_succeeds_when_hash_missing():
+    """When the hash lookup fails, the CivitAI name search is used and the
+    preview/metadata are fetched from the matched model version."""
+    name_metadata = {
+        "id": 123,
+        "modelId": 456,
+        "name": "Remote Model",
+        "model": {"name": "Remote Model", "type": "LORA"},
+        "images": [{"url": "https://example.com/preview.webp"}],
+    }
+    provider = SimpleNamespace(
+        get_model_by_hash=AsyncMock(return_value=(None, "Model not found")),
+        get_model_by_name=AsyncMock(return_value=(name_metadata, None)),
+        get_model_version=AsyncMock(),
+    )
+    helpers = build_service(default_provider=provider)
+
+    model_path = "/tmp/model.ckpt"
+    model_data = {
+        "model_name": "local_model",
+        "file_name": "local_model",
+        "file_path": model_path,
+        "folder": "",
+    }
+    update_cache = AsyncMock()
+
+    ok, error = await helpers.service.fetch_and_update_model(
+        sha256="hash-not-on-civitai",
+        file_path=model_path,
+        model_data=model_data,
+        update_cache_func=update_cache,
+    )
+
+    assert ok and error is None
+    # The name search must have been attempted with the stripped file name
+    provider.get_model_by_name.assert_awaited_once()
+    assert provider.get_model_by_name.await_args.args[0] == "local_model"
+    # Model is now linked to CivitAI via the name match
+    assert model_data["from_civitai"] is True
+    assert model_data.get("civitai_deleted") is not True
+    assert model_data["civitai"]["name"] == "Remote Model"
+    update_cache.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_update_model_name_fallback_recover_deleted():
+    """A model previously marked civitai_deleted (e.g. Draw Things converted
+    checkpoint whose hash is unknown to CivitAI) is recovered by the name
+    fallback: the deleted flag is cleared and metadata attached."""
+    name_metadata = {
+        "id": 99,
+        "modelId": 88,
+        "name": "Anything2Real",
+        "model": {"name": "Anything2Real", "type": "LORA"},
+        "images": [{"url": "https://example.com/preview.webp"}],
+    }
+    provider = SimpleNamespace(
+        get_model_by_hash=AsyncMock(return_value=(None, "Model not found")),
+        get_model_by_name=AsyncMock(return_value=(name_metadata, None)),
+        get_model_version=AsyncMock(),
+    )
+    helpers = build_service(
+        settings_values={"enable_metadata_archive_db": False},
+        default_provider=provider,
+    )
+
+    model_path = "/tmp/model.ckpt"
+    model_data = {
+        "civitai_deleted": True,
+        "from_civitai": False,
+        "model_name": "anything2real_a_lora_f16",
+        "file_name": "anything2real_a_lora_f16",
+        "file_path": model_path,
+        "folder": "",
+    }
+    update_cache = AsyncMock()
+
+    ok, error = await helpers.service.fetch_and_update_model(
+        sha256="converted-hash-not-on-civitai",
+        file_path=model_path,
+        model_data=model_data,
+        update_cache_func=update_cache,
+    )
+
+    assert ok and error is None
+    provider.get_model_by_name.assert_awaited_once()
+    assert provider.get_model_by_name.await_args.args[0] == "anything2real_a_lora_f16"
+    assert model_data["from_civitai"] is True
+    assert model_data["civitai_deleted"] is False
+    assert model_data["name_fallback_checked"] is True
+    assert model_data["civitai"]["name"] == "Anything2Real"
+    update_cache.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_update_model_name_fallback_disabled():
+    """When civitai_name_fallback is disabled, a missing hash is reported as
+    not found without attempting the name search."""
+    provider = SimpleNamespace(
+        get_model_by_hash=AsyncMock(return_value=(None, "Model not found")),
+        get_model_by_name=AsyncMock(),
+        get_model_version=AsyncMock(),
+    )
+    helpers = build_service(
+        settings_values={"civitai_name_fallback": False},
+        default_provider=provider,
+    )
+
+    model_path = "/tmp/model.ckpt"
+    model_data = {
+        "model_name": "local_model",
+        "file_name": "local_model",
+        "file_path": model_path,
+        "folder": "",
+    }
+
+    ok, error = await helpers.service.fetch_and_update_model(
+        sha256="hash-not-on-civitai",
+        file_path=model_path,
+        model_data=model_data,
+        update_cache_func=AsyncMock(),
+    )
+
+    assert not ok
+    assert "Model not found" in error
+    provider.get_model_by_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_update_model_name_fallback_transient_error_not_marked():
+    """A transient name-search failure (e.g. CivitAI search overload) must NOT
+    persist name_fallback_checked, so a later refresh can retry the fallback."""
+    provider = SimpleNamespace(
+        get_model_by_hash=AsyncMock(return_value=(None, "Model not found")),
+        get_model_by_name=AsyncMock(
+            return_value=(None, "Model search is temporarily overloaded")
+        ),
+        get_model_version=AsyncMock(),
+    )
+    helpers = build_service(
+        settings_values={"enable_metadata_archive_db": False},
+        default_provider=provider,
+    )
+
+    model_path = "/tmp/model.ckpt"
+    model_data = {
+        "model_name": "anything2real_a_lora_f16",
+        "file_name": "anything2real_a_lora_f16",
+        "file_path": model_path,
+        "folder": "",
+    }
+    update_cache = AsyncMock()
+
+    ok, error = await helpers.service.fetch_and_update_model(
+        sha256="converted-hash-not-on-civitai",
+        file_path=model_path,
+        model_data=model_data,
+        update_cache_func=update_cache,
+    )
+
+    assert not ok
+    provider.get_model_by_name.assert_awaited_once()
+    # The transient failure must not poison the fallback for later retries.
+    assert model_data.get("name_fallback_checked") is not True
+    # It must not be re-classified as deleted either.
+    assert model_data.get("civitai_deleted") is not True
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_update_model_name_fallback_definitive_miss_marked():
+    """A definitive 'Model not found' from the name search IS persisted so
+    subsequent refresh cycles do not re-hit the search endpoint."""
+    provider = SimpleNamespace(
+        get_model_by_hash=AsyncMock(return_value=(None, "Model not found")),
+        get_model_by_name=AsyncMock(return_value=(None, "Model not found")),
+        get_model_version=AsyncMock(),
+    )
+    helpers = build_service(
+        settings_values={"enable_metadata_archive_db": False},
+        default_provider=provider,
+    )
+
+    model_path = "/tmp/model.ckpt"
+    model_data = {
+        "model_name": "some_unknown_model",
+        "file_name": "some_unknown_model",
+        "file_path": model_path,
+        "folder": "",
+    }
+
+    ok, error = await helpers.service.fetch_and_update_model(
+        sha256="converted-hash-not-on-civitai",
+        file_path=model_path,
+        model_data=model_data,
+        update_cache_func=AsyncMock(),
+    )
+
+    assert not ok
+    assert "Model not found" in error
+    assert model_data.get("name_fallback_checked") is True

--- a/tests/services/test_model_metadata_provider.py
+++ b/tests/services/test_model_metadata_provider.py
@@ -124,6 +124,37 @@ async def test_fallback_continues_to_next_provider_on_rate_limit(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fallback_get_model_by_name_uses_supporting_provider():
+    """Name lookup is delegated to the first provider exposing get_model_by_name."""
+    provider_with_name = AsyncMock()
+    provider_with_name.get_model_by_name = AsyncMock(
+        return_value=({"id": "named"}, None)
+    )
+    provider_without_name = AsyncMock()  # lacks get_model_by_name entirely
+
+    fallback = FallbackMetadataProvider(
+        [("no_search", provider_without_name), ("searchable", provider_with_name)],
+    )
+
+    result, error = await fallback.get_model_by_name(
+        "anything2real_a",
+        model_types=("LORA", "Checkpoint"),
+    )
+
+    assert error is None
+    assert result == {"id": "named"}
+    provider_with_name.get_model_by_name.assert_awaited_once()
+    assert (
+        provider_with_name.get_model_by_name.await_args.args[0]
+        == "anything2real_a"
+    )
+    assert (
+        provider_with_name.get_model_by_name.await_args.kwargs["model_types"]
+        == ("LORA", "Checkpoint")
+    )
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_retrying_provider_retries(monkeypatch):
     sleep_mock = AsyncMock()
     monkeypatch.setattr(provider_module.asyncio, "sleep", sleep_mock)

--- a/tests/services/test_use_cases.py
+++ b/tests/services/test_use_cases.py
@@ -90,10 +90,13 @@ class StubMetadataSync(MetadataSyncService):
 @dataclass
 class StubSettings:
     enable_metadata_archive_db: bool = False
+    civitai_name_fallback: bool = True
 
     def get(self, key: str, default: Any = None) -> Any:
         if key == "enable_metadata_archive_db":
             return self.enable_metadata_archive_db
+        if key == "civitai_name_fallback":
+            return self.civitai_name_fallback
         return default
 
 
@@ -279,7 +282,7 @@ async def test_bulk_metadata_refresh_skips_confirmed_not_found_models(
     ]
     service = MockModelService(scanner)
     metadata_sync = StubMetadataSync()
-    settings = StubSettings(enable_metadata_archive_db=False)
+    settings = StubSettings(enable_metadata_archive_db=False, civitai_name_fallback=False)
     progress = ProgressCollector()
 
     async def fake_hydrate(model_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -330,7 +333,9 @@ async def test_bulk_metadata_refresh_skips_when_archive_checked(
     ]
     service = MockModelService(scanner)
     metadata_sync = StubMetadataSync()
-    settings = StubSettings(enable_metadata_archive_db=True)
+    settings = StubSettings(
+        enable_metadata_archive_db=True, civitai_name_fallback=False
+    )
     progress = ProgressCollector()
 
     async def fake_hydrate(model_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/services/use_cases/test_bulk_metadata_refresh_use_case.py
+++ b/tests/services/use_cases/test_bulk_metadata_refresh_use_case.py
@@ -402,3 +402,114 @@ async def test_model_without_hash_skipped(use_case, mock_service, mock_metadata_
 
     assert result["processed"] == 1
     assert result["updated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_deleted_model_not_skipped_when_name_fallback_pending(
+    mock_service, mock_metadata_sync, mock_settings
+):
+    """A model previously marked civitai_deleted (e.g. Draw Things converted
+    checkpoint) is NOT skipped when the name-based fallback is enabled and has
+    not yet reached a definitive miss — it must be retried via the name search."""
+    mock_settings.get = MagicMock(
+        side_effect=lambda key, default=None: {
+            "enable_metadata_archive_db": False,
+            "civitai_name_fallback": True,
+        }.get(key, default)
+    )
+    use_case = BulkMetadataRefreshUseCase(
+        service=mock_service,
+        metadata_sync=mock_metadata_sync,
+        settings_service=mock_settings,
+    )
+    deleted_model = {
+        "file_path": "/models/anything2real_a_lora_f16.ckpt",
+        "sha256": "converted-hash",
+        "model_name": "anything2real_a_lora_f16",
+        "civitai": {},
+        "from_civitai": False,
+        "civitai_deleted": True,
+    }
+
+    cache = SimpleNamespace(raw_data=[deleted_model], resort=AsyncMock())
+    mock_service.scanner.get_cached_data.return_value = cache
+
+    result = await use_case.execute()
+
+    # The model must be processed via the name fallback, not skipped.
+    mock_metadata_sync.fetch_and_update_model.assert_awaited_once()
+    assert result["processed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_deleted_model_skipped_when_name_fallback_definitive(
+    mock_service, mock_metadata_sync, mock_settings
+):
+    """A model whose name fallback already reached a definitive miss IS skipped
+    to avoid re-hitting the search endpoint on every refresh."""
+    mock_settings.get = MagicMock(
+        side_effect=lambda key, default=None: {
+            "enable_metadata_archive_db": False,
+            "civitai_name_fallback": True,
+        }.get(key, default)
+    )
+    use_case = BulkMetadataRefreshUseCase(
+        service=mock_service,
+        metadata_sync=mock_metadata_sync,
+        settings_service=mock_settings,
+    )
+    deleted_model = {
+        "file_path": "/models/some_unknown_model.ckpt",
+        "sha256": "converted-hash",
+        "model_name": "some_unknown_model",
+        "civitai": {},
+        "from_civitai": False,
+        "civitai_deleted": True,
+        "name_fallback_checked": True,
+    }
+
+    cache = SimpleNamespace(raw_data=[deleted_model], resort=AsyncMock())
+    mock_service.scanner.get_cached_data.return_value = cache
+
+    result = await use_case.execute()
+
+    mock_metadata_sync.fetch_and_update_model.assert_not_awaited()
+    assert result["processed"] == 0
+    assert result["updated"] == 0
+    assert result["skipped_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_deleted_model_skipped_when_name_fallback_disabled(
+    mock_service, mock_metadata_sync, mock_settings
+):
+    """When the name fallback is disabled, deleted models behave as before."""
+    mock_settings.get = MagicMock(
+        side_effect=lambda key, default=None: {
+            "enable_metadata_archive_db": False,
+            "civitai_name_fallback": False,
+        }.get(key, default)
+    )
+    use_case = BulkMetadataRefreshUseCase(
+        service=mock_service,
+        metadata_sync=mock_metadata_sync,
+        settings_service=mock_settings,
+    )
+    deleted_model = {
+        "file_path": "/models/some_deleted_model.ckpt",
+        "sha256": "hash",
+        "model_name": "some_deleted_model",
+        "civitai": {},
+        "from_civitai": False,
+        "civitai_deleted": True,
+    }
+
+    cache = SimpleNamespace(raw_data=[deleted_model], resort=AsyncMock())
+    mock_service.scanner.get_cached_data.return_value = cache
+
+    result = await use_case.execute()
+
+    mock_metadata_sync.fetch_and_update_model.assert_not_awaited()
+    assert result["processed"] == 0
+    assert result["updated"] == 0
+    assert result["skipped_count"] == 1

--- a/tests/standalone/test_standalone_server.py
+++ b/tests/standalone/test_standalone_server.py
@@ -10,8 +10,6 @@ from typing import Any, Generator, List, Tuple
 import pytest
 from aiohttp import web
 
-from py.utils.settings_paths import ensure_settings_file
-
 
 ROUTE_CALLS_KEY: web.AppKey[List[Tuple[str, dict[str, Any]]]] = web.AppKey("route_calls")
 
@@ -54,22 +52,41 @@ def standalone_module(monkeypatch) -> Generator[ModuleType, None, None]:
         sys.modules.pop("py.lora_manager", None)
 
 
-def _write_settings(contents: dict[str, Any]) -> Path:
+@pytest.fixture
+def isolated_settings(standalone_module, tmp_path, monkeypatch) -> Path:
+    """Point the standalone module's settings resolution into *tmp_path*.
+
+    ``standalone`` imports ``ensure_settings_file`` by name, so patching
+    ``py.utils.settings_paths`` alone is not enough — the module attribute
+    must be replaced directly.  Without this, ``ensure_settings_file()``
+    would resolve to the developer's real project ``settings.json`` and
+    tests could overwrite or even migrate (i.e. delete) it.
+    """
+
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(
+        standalone_module,
+        "ensure_settings_file",
+        lambda *args, **kwargs: str(settings_path),
+    )
+    return settings_path
+
+
+def _write_settings(contents: dict[str, Any], settings_path: Path) -> Path:
     """Persist *contents* into the isolated settings.json."""
 
-    settings_path = Path(ensure_settings_file())
     settings_path.write_text(json.dumps(contents))
     return settings_path
 
 
-async def test_standalone_server_sets_up_routes(tmp_path, standalone_module):
+async def test_standalone_server_sets_up_routes(tmp_path, standalone_module, isolated_settings):
     """``StandaloneServer.setup`` wires the HTTP routes and lifecycle hooks."""
 
     example_images_dir = tmp_path / "example_images"
     example_images_dir.mkdir()
     (example_images_dir / "preview.png").write_text("placeholder")
 
-    _write_settings({"example_images_path": str(example_images_dir)})
+    _write_settings({"example_images_path": str(example_images_dir)}, isolated_settings)
 
     server = standalone_module.StandaloneServer()
     await server.setup()
@@ -93,7 +110,7 @@ def test_standalone_server_raises_header_limits(standalone_module):
     assert server.app._handler_args["max_line_size"] == standalone_module.HEADER_SIZE_LIMIT
 
 
-def test_validate_settings_warns_for_missing_model_paths(caplog, standalone_module):
+def test_validate_settings_warns_for_missing_model_paths(caplog, standalone_module, isolated_settings):
     """Missing model folders trigger the configuration warning."""
 
     caplog.set_level("WARNING")
@@ -105,7 +122,8 @@ def test_validate_settings_warns_for_missing_model_paths(caplog, standalone_modu
                 "checkpoints": [],
                 "embeddings": [],
             }
-        }
+        },
+        isolated_settings,
     )
 
     assert standalone_module.validate_settings() is True

--- a/tests/test_standalone_settings.py
+++ b/tests/test_standalone_settings.py
@@ -34,6 +34,15 @@ def read_example_settings() -> dict[str, Any]:
 
 
 def test_missing_settings_creates_defaults_and_emits_warnings(tmp_path):
+    """Missing settings file triggers defaults creation and warnings."""
+
+    # ``ensure_settings_file()`` may already seed a template settings.json on
+    # first run; the manager must treat a *deleted* file as "missing" to
+    # exercise the bootstrap path this test verifies.
+    settings_path = Path(settings_paths.ensure_settings_file())
+    if settings_path.exists():
+        settings_path.unlink()
+
     manager = get_settings_manager()
     settings_path = Path(manager.settings_file)
 


### PR DESCRIPTION
## Problem

Draw Things converts LoRA/checkpoint files to f16/q8bit, which changes their SHA256 hashes. As a result, CivitAI hash lookups reliably fail with "Model not found" for every converted model — metadata and preview images can never be fetched, even though the underlying model is published on CivitAI.

## Solution

Add a **name-based fallback**: when every metadata provider misses by hash, search CivitAI's `/models` endpoint by the model's file name and fetch metadata + preview image from the best matching LORA/Checkpoint version.

### Key changes

- `civitai_client.py`: new `get_model_by_name()` — searches `/models`, filters to LORA/Checkpoint, ranks candidates by title similarity, and enriches the best version with model-level data (description, tags, license, creator)
- `model_metadata_provider.py`: delegates name lookup through `CivitaiModelMetadataProvider` and `FallbackMetadataProvider`
- `metadata_sync_service.py`: falls back to name search when hash lookup fails; only persists `name_fallback_checked` on a **definitive** miss so transient search overloads do not poison later retries; transient failures no longer classify the model as `civitai_deleted`
- `bulk_metadata_refresh_use_case.py`: no longer skips `civitai_deleted` models when the name fallback is enabled and has not reached a definitive miss
- `settings_manager.py`: new `civitai_name_fallback` setting (default `true`)

## Tests

97 backend tests pass, including new coverage for:
- name-search matching, ranking, and enrichment
- deleted-model recovery via name fallback
- transient-vs-definitive marker behavior
- bulk-refresh skip logic with fallback enabled/disabled

## Notes

This is scoped to metadata/preview fetching only — the AI Provider (LLM) settings are unrelated and untouched.
