### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,4 +350,4 @@ Join our Discord community for support, discussions, and updates:
 ---
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=willmiao/ComfyUI-Lora-Manager&type=Date)](https://star-history.com/#willmiao/ComfyUI-Lora-Manager&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=willmiao/ComfyUI-Lora-Manager&type=Date)](https://star-history.dera.page/#willmiao/ComfyUI-Lora-Manager&Date)


### PR DESCRIPTION
The Star History chart in the README stopped working because the old provider's chart endpoint is broken. This switches the chart image and its link to a working alternative that requires no API token, so the chart displays correctly again.