### PR TITLE
fix(recipes): gate first load on scan completion instead of showing an empty page

### DIFF
--- a/py/routes/handlers/misc_handlers.py
+++ b/py/routes/handlers/misc_handlers.py
@@ -649,8 +649,59 @@ class NodeRegistry:
 
 
 class HealthCheckHandler:
+    def __init__(
+        self,
+        scanner_getters: Mapping[str, Callable[[], Awaitable[Any]]] | None = None,
+    ) -> None:
+        self._scanner_getters = scanner_getters or {
+            "lora": ServiceRegistry.get_lora_scanner,
+            "checkpoint": ServiceRegistry.get_checkpoint_scanner,
+            "embedding": ServiceRegistry.get_embedding_scanner,
+            "recipe": ServiceRegistry.get_recipe_scanner,
+        }
+
     async def health_check(self, request: web.Request) -> web.Response:
         return web.json_response({"status": "ok"})
+
+    async def get_init_status(self, request: web.Request) -> web.Response:
+        """Report aggregate scanner initialization status.
+
+        Used by the initialization page's polling fallback when the
+        /ws/init-progress WebSocket is unavailable. Omits pageType so every
+        page accepts the update and only reloads once all scanners are done.
+        """
+        pending: list[str] = []
+        for name, getter in self._scanner_getters.items():
+            try:
+                scanner = await getter()
+            except Exception:
+                pending.append(name)
+                continue
+            cache_ready = getattr(scanner, "_cache", None) is not None
+            is_initializing = getattr(scanner, "is_initializing", None)
+            busy = (
+                is_initializing()
+                if callable(is_initializing)
+                else bool(getattr(scanner, "_is_initializing", False))
+            )
+            if busy or not cache_ready:
+                pending.append(name)
+
+        if pending:
+            return web.json_response(
+                {
+                    "status": "initializing",
+                    "stage": "processing",
+                    "details": "Initializing: " + ", ".join(pending),
+                }
+            )
+        return web.json_response(
+            {
+                "status": "complete",
+                "progress": 100,
+                "details": "Initialization complete",
+            }
+        )
 
 
 class SupportersHandler:
@@ -3859,6 +3910,7 @@ class MiscHandlerSet:
     ) -> Mapping[str, Callable[[web.Request], Awaitable[web.StreamResponse]]]:
         return {
             "health_check": self.health.health_check,
+            "get_init_status": self.health.get_init_status,
             "get_settings": self.settings.get_settings,
             "update_settings": self.settings.update_settings,
             "get_doctor_diagnostics": self.doctor.get_doctor_diagnostics,

--- a/py/routes/handlers/recipe_handlers.py
+++ b/py/routes/handlers/recipe_handlers.py
@@ -176,11 +176,19 @@ class RecipePageView:
             user_language = self._settings.get("language", "en")
             self._server_i18n.set_locale(user_language)
 
+            # While the initial scan is running, show the initialization
+            # screen (same as the model pages) instead of an empty grid; the
+            # page reloads itself when the scanner broadcasts completion.
+            is_initializing = (
+                recipe_scanner._cache is None or recipe_scanner.is_initializing()
+            )
+
             try:
-                await recipe_scanner.get_cached_data(force_refresh=False)
+                if not is_initializing:
+                    await recipe_scanner.get_cached_data(force_refresh=False)
                 rendered = self._template_env.get_template(self._template_name).render(
                     recipes=[],
-                    is_initializing=False,
+                    is_initializing=is_initializing,
                     settings=self._settings,
                     request=request,
                     t=self._server_i18n.get_translation,

--- a/py/routes/misc_route_registrar.py
+++ b/py/routes/misc_route_registrar.py
@@ -32,6 +32,7 @@ MISC_ROUTE_DEFINITIONS: tuple[RouteDefinition, ...] = (
     RouteDefinition("GET", "/api/lm/settings/libraries", "get_settings_libraries"),
     RouteDefinition("POST", "/api/lm/settings/libraries/activate", "activate_library"),
     RouteDefinition("GET", "/api/lm/health-check", "health_check"),
+    RouteDefinition("GET", "/api/lm/init-status", "get_init_status"),
     RouteDefinition("GET", "/api/lm/supporters", "get_supporters"),
     RouteDefinition("GET", "/api/lm/wildcards/search", "search_wildcards"),
     RouteDefinition("POST", "/api/lm/wildcards/open-location", "open_wildcards_location"),

--- a/py/services/recipe_scanner.py
+++ b/py/services/recipe_scanner.py
@@ -1404,6 +1404,11 @@ class RecipeScanner:
 
     async def initialize_in_background(self) -> None:
         """Initialize cache in background using thread pool"""
+        # Mark as initializing before any await so concurrent callers can
+        # wait on this task instead of observing the placeholder empty cache
+        # (the LoRA scanner wait below can take a while at startup).
+        self._is_initializing = True
+        self._initialization_task = asyncio.current_task()
         try:
             await self._wait_for_lora_scanner()
 
@@ -1417,39 +1422,34 @@ class RecipeScanner:
                     folder_tree={},
                 )
 
-            # Mark as initializing to prevent concurrent initializations
-            self._is_initializing = True
-            self._initialization_task = asyncio.current_task()
+            # Start timer
+            start_time = time.time()
 
-            try:
-                # Start timer
-                start_time = time.time()
+            # Use thread pool to execute CPU-intensive operations
+            loop = asyncio.get_event_loop()
+            cache = await loop.run_in_executor(
+                None,  # Use default thread pool
+                self._initialize_recipe_cache_sync,  # Run synchronous version in thread
+            )
+            if cache is not None:
+                self._cache = cache
 
-                # Use thread pool to execute CPU-intensive operations
-                loop = asyncio.get_event_loop()
-                cache = await loop.run_in_executor(
-                    None,  # Use default thread pool
-                    self._initialize_recipe_cache_sync,  # Run synchronous version in thread
-                )
-                if cache is not None:
-                    self._cache = cache
-
-                # Calculate elapsed time and log it
-                elapsed_time = time.time() - start_time
-                recipe_count = (
-                    len(cache.raw_data) if cache and hasattr(cache, "raw_data") else 0
-                )
-                logger.info(
-                    f"Recipe cache initialized in {elapsed_time:.2f} seconds. Found {recipe_count} recipes"
-                )
-                self._schedule_post_scan_enrichment()
-                # Schedule FTS index build in background (non-blocking)
-                self._schedule_fts_index_build()
-            finally:
-                # Mark initialization as complete regardless of outcome
-                self._is_initializing = False
+            # Calculate elapsed time and log it
+            elapsed_time = time.time() - start_time
+            recipe_count = (
+                len(cache.raw_data) if cache and hasattr(cache, "raw_data") else 0
+            )
+            logger.info(
+                f"Recipe cache initialized in {elapsed_time:.2f} seconds. Found {recipe_count} recipes"
+            )
+            self._schedule_post_scan_enrichment()
+            # Schedule FTS index build in background (non-blocking)
+            self._schedule_fts_index_build()
         except Exception as e:
             logger.error(f"Recipe Scanner: Error initializing cache in background: {e}")
+        finally:
+            # Mark initialization as complete regardless of outcome
+            self._is_initializing = False
 
     def _initialize_recipe_cache_sync(self):
         """Synchronous version of recipe cache initialization for thread pool execution.
@@ -2254,20 +2254,27 @@ class RecipeScanner:
 
     async def get_cached_data(self, force_refresh: bool = False) -> RecipeCache:
         """Get cached recipe data, refresh if needed"""
+        # If a background initialization is in progress, wait for it to
+        # complete so callers never observe the placeholder empty cache.
+        initialization_task = self._initialization_task
+        if (
+            self._is_initializing
+            and not force_refresh
+            and initialization_task is not None
+            and initialization_task is not asyncio.current_task()
+            and not initialization_task.done()
+        ):
+            try:
+                await initialization_task
+            except Exception:
+                # Initialization failures are logged by the task itself; fall
+                # through and return whatever cache state we have.
+                pass
+
         # If cache is already initialized and no refresh is needed, return it immediately
         if self._cache is not None and not force_refresh:
             self._update_folder_metadata()
             return cast(RecipeCache, self._cache)
-
-        # If another initialization is already in progress, wait for it to complete
-        if self._is_initializing and not force_refresh:
-            return self._cache or RecipeCache(
-                raw_data=[],
-                sorted_by_name=[],
-                sorted_by_date=[],
-                folders=[],
-                folder_tree={},
-            )
 
         # If force refresh is requested, re-scan in a thread pool to avoid
         # blocking the event loop (which is shared with ComfyUI).

--- a/py/services/recipe_scanner.py
+++ b/py/services/recipe_scanner.py
@@ -19,6 +19,7 @@ from ..utils.recipe_open_stats import RecipeOpenStats
 from .model_scanner import WEIGHT_FILE_EXTENSIONS
 from .recipe_cache import RecipeCache
 from .recipes.errors import RecipeNotFoundError, RecipePersistenceError
+from .websocket_manager import ws_manager
 from natsort import natsorted
 import sys
 import re
@@ -480,6 +481,10 @@ class RecipeScanner:
             if value:
                 return str(value)
         return "unknown"
+
+    def is_initializing(self) -> bool:
+        """Check if the scanner is currently initializing"""
+        return self._is_initializing
 
     def on_library_changed(self) -> None:
         """Reset cached state when the active library changes."""
@@ -1410,6 +1415,14 @@ class RecipeScanner:
         self._is_initializing = True
         self._initialization_task = asyncio.current_task()
         try:
+            await ws_manager.broadcast_init_progress({
+                'stage': 'loading_cache',
+                'progress': 0,
+                'details': 'Loading recipe cache...',
+                'scanner_type': 'recipe',
+                'pageType': 'recipes',
+            })
+
             await self._wait_for_lora_scanner()
 
             # Set initial empty cache to avoid None reference errors
@@ -1442,11 +1455,38 @@ class RecipeScanner:
             logger.info(
                 f"Recipe cache initialized in {elapsed_time:.2f} seconds. Found {recipe_count} recipes"
             )
+            await ws_manager.broadcast_init_progress({
+                'stage': 'finalizing',
+                'progress': 100,
+                'status': 'complete',
+                'details': f'Found {recipe_count} recipes.',
+                'scanner_type': 'recipe',
+                'pageType': 'recipes',
+            })
             self._schedule_post_scan_enrichment()
             # Schedule FTS index build in background (non-blocking)
             self._schedule_fts_index_build()
         except Exception as e:
             logger.error(f"Recipe Scanner: Error initializing cache in background: {e}")
+            # Ensure the cache is never None so the page stops showing the
+            # initialization screen, and let waiting clients reload into the
+            # regular (possibly empty) view instead of stalling.
+            if self._cache is None:
+                self._cache = RecipeCache(
+                    raw_data=[],
+                    sorted_by_name=[],
+                    sorted_by_date=[],
+                    folders=[],
+                    folder_tree={},
+                )
+            await ws_manager.broadcast_init_progress({
+                'stage': 'finalizing',
+                'progress': 100,
+                'status': 'complete',
+                'details': 'Recipe cache initialization failed.',
+                'scanner_type': 'recipe',
+                'pageType': 'recipes',
+            })
         finally:
             # Mark initialization as complete regardless of outcome
             self._is_initializing = False

--- a/static/js/components/SidebarManager.js
+++ b/static/js/components/SidebarManager.js
@@ -1841,6 +1841,16 @@ export class SidebarManager {
                     this.pageControls.pageState.activeFolder = '';
                 }
                 setStorageItem(`${this.pageType}_activeFolder`, '');
+                // When the reset happens after initialization (e.g. via
+                // refresh() after a drag move emptied the folder), reload the
+                // listing so the grid shows the root contents instead of
+                // staying empty. Skipped during initialize() — the first load
+                // picks up the cleared filter on its own.
+                if (this.isInitialized && typeof this.pageControls?.resetAndReload === 'function') {
+                    this.pageControls.resetAndReload().catch((error) => {
+                        console.error('Failed to reload after resetting folder selection:', error);
+                    });
+                }
             } else {
                 this.selectedPath = activeFolder;
             }

--- a/static/js/components/SidebarManager.js
+++ b/static/js/components/SidebarManager.js
@@ -16,6 +16,7 @@ export class SidebarManager {
         this.pageControls = null;
         this.pageType = null;
         this.treeData = {};
+        this.folderTreeLoaded = false;
         this.selectedPath = '';
         this.expandedNodes = new Set();
         this.apiClient = null;
@@ -1171,11 +1172,30 @@ export class SidebarManager {
                 const response = await this.apiClient.fetchModelFolders();
                 this.foldersList = response.folders || [];
             }
+            this.folderTreeLoaded = true;
             this.renderFolderDisplay();
         } catch (error) {
+            this.folderTreeLoaded = false;
             console.error('Failed to load folder data:', error);
             this.renderEmptyState();
         }
+    }
+
+    folderExistsInTree(path) {
+        if (!path) return true;
+
+        if (this.displayMode === 'tree') {
+            let node = this.treeData;
+            for (const segment of path.split('/')) {
+                if (!node || typeof node !== 'object' || !(segment in node)) {
+                    return false;
+                }
+                node = node[segment];
+            }
+            return true;
+        }
+
+        return this.foldersList.includes(path);
     }
 
     renderFolderDisplay() {
@@ -1809,7 +1829,21 @@ export class SidebarManager {
     restoreSelectedFolder() {
         const activeFolder = getStorageItem(`${this.pageType}_activeFolder`);
         if (activeFolder && typeof activeFolder === 'string') {
-            this.selectedPath = activeFolder;
+            // Fall back to the root when the persisted folder no longer
+            // exists in the freshly loaded tree (e.g. it was moved or
+            // deleted); otherwise the grid stays empty with a phantom
+            // breadcrumb. Skip validation when the tree failed to load so a
+            // transient API error doesn't wipe the saved location.
+            if (this.folderTreeLoaded && !this.folderExistsInTree(activeFolder)) {
+                console.warn(`Persisted folder "${activeFolder}" not found in folder tree, falling back to root`);
+                this.selectedPath = '';
+                if (this.pageControls?.pageState) {
+                    this.pageControls.pageState.activeFolder = '';
+                }
+                setStorageItem(`${this.pageType}_activeFolder`, '');
+            } else {
+                this.selectedPath = activeFolder;
+            }
             this.updateTreeSelection();
             this.updateBreadcrumbs();
             this.updateSidebarHeader();

--- a/static/js/components/initialization.js
+++ b/static/js/components/initialization.js
@@ -52,7 +52,11 @@ class InitializationManager {
     detectPageType() {
         // Get the current page type from URL or data attribute
         const path = window.location.pathname;
-        if (path.includes('/checkpoints')) {
+        // The recipes page lives at /loras/recipes, so it must be matched
+        // before the generic '/loras' check.
+        if (path.includes('/recipes')) {
+            this.pageType = 'recipes';
+        } else if (path.includes('/checkpoints')) {
             this.pageType = 'checkpoints';
         } else if (path.includes('/loras')) {
             this.pageType = 'loras';
@@ -216,7 +220,8 @@ class InitializationManager {
             const scannerTypeToPageType = {
                 'lora': 'loras',
                 'checkpoint': 'checkpoints',
-                'embedding': 'embeddings'
+                'embedding': 'embeddings',
+                'recipe': 'recipes'
             };
             
             if (scannerTypeToPageType[data.scanner_type] !== this.pageType) {

--- a/tests/frontend/components/sidebarManager.restoreFolder.test.js
+++ b/tests/frontend/components/sidebarManager.restoreFolder.test.js
@@ -1,0 +1,127 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+
+const {
+  SIDEBAR_MANAGER_MODULE,
+  STORAGE_HELPERS_MODULE,
+  MODEL_API_FACTORY_MODULE,
+  I18N_MODULE,
+  BULK_MANAGER_MODULE,
+  UI_HELPERS_MODULE,
+  UPDATE_CHECK_MODULE,
+} = vi.hoisted(() => ({
+  SIDEBAR_MANAGER_MODULE: new URL('../../../static/js/components/SidebarManager.js', import.meta.url).pathname,
+  STORAGE_HELPERS_MODULE: new URL('../../../static/js/utils/storageHelpers.js', import.meta.url).pathname,
+  MODEL_API_FACTORY_MODULE: new URL('../../../static/js/api/modelApiFactory.js', import.meta.url).pathname,
+  I18N_MODULE: new URL('../../../static/js/utils/i18nHelpers.js', import.meta.url).pathname,
+  BULK_MANAGER_MODULE: new URL('../../../static/js/managers/BulkManager.js', import.meta.url).pathname,
+  UI_HELPERS_MODULE: new URL('../../../static/js/utils/uiHelpers.js', import.meta.url).pathname,
+  UPDATE_CHECK_MODULE: new URL('../../../static/js/utils/updateCheckHelpers.js', import.meta.url).pathname,
+}));
+
+vi.mock(MODEL_API_FACTORY_MODULE, () => ({ getModelApiClient: vi.fn() }));
+vi.mock(I18N_MODULE, () => ({ translate: (key, _args, fallback) => fallback || key }));
+vi.mock(BULK_MANAGER_MODULE, () => ({ bulkManager: {} }));
+vi.mock(UI_HELPERS_MODULE, () => ({ showToast: vi.fn() }));
+vi.mock(UPDATE_CHECK_MODULE, () => ({ performFolderUpdateCheck: vi.fn() }));
+
+const { SidebarManager } = await import(SIDEBAR_MANAGER_MODULE);
+const { setStorageItem, getStorageItem } = await import(STORAGE_HELPERS_MODULE);
+
+function createManager({
+  treeData = {},
+  foldersList = [],
+  displayMode = 'tree',
+  folderTreeLoaded = true,
+  isInitialized = true,
+  persistedFolder = 'Civitai/_Missing',
+} = {}) {
+  const manager = new SidebarManager();
+  manager.pageType = 'recipes';
+  manager.displayMode = displayMode;
+  manager.treeData = treeData;
+  manager.foldersList = foldersList;
+  manager.folderTreeLoaded = folderTreeLoaded;
+  manager.isInitialized = isInitialized;
+  manager.updateTreeSelection = vi.fn();
+  manager.updateBreadcrumbs = vi.fn();
+  manager.updateSidebarHeader = vi.fn();
+
+  const resetAndReload = vi.fn().mockResolvedValue(undefined);
+  manager.pageControls = {
+    pageState: { activeFolder: persistedFolder },
+    resetAndReload,
+  };
+
+  if (persistedFolder !== null) {
+    setStorageItem('recipes_activeFolder', persistedFolder);
+  }
+
+  return { manager, resetAndReload };
+}
+
+describe('SidebarManager.restoreSelectedFolder', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('falls back to root and reloads when the persisted folder is missing', () => {
+    const { manager, resetAndReload } = createManager({
+      treeData: { Civitai: {} },
+    });
+
+    manager.restoreSelectedFolder();
+
+    expect(manager.selectedPath).toBe('');
+    expect(manager.pageControls.pageState.activeFolder).toBe('');
+    expect(getStorageItem('recipes_activeFolder')).toBe('');
+    expect(resetAndReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the persisted folder when it exists in the tree', () => {
+    const { manager, resetAndReload } = createManager({
+      treeData: { Civitai: { _Missing: {} } },
+    });
+
+    manager.restoreSelectedFolder();
+
+    expect(manager.selectedPath).toBe('Civitai/_Missing');
+    expect(manager.pageControls.pageState.activeFolder).toBe('Civitai/_Missing');
+    expect(resetAndReload).not.toHaveBeenCalled();
+  });
+
+  it('resets without reloading during initial initialization', () => {
+    const { manager, resetAndReload } = createManager({
+      treeData: { Civitai: {} },
+      isInitialized: false,
+    });
+
+    manager.restoreSelectedFolder();
+
+    expect(manager.selectedPath).toBe('');
+    expect(resetAndReload).not.toHaveBeenCalled();
+  });
+
+  it('keeps the persisted folder when the tree failed to load', () => {
+    const { manager, resetAndReload } = createManager({
+      treeData: {},
+      folderTreeLoaded: false,
+    });
+
+    manager.restoreSelectedFolder();
+
+    expect(manager.selectedPath).toBe('Civitai/_Missing');
+    expect(resetAndReload).not.toHaveBeenCalled();
+  });
+
+  it('validates against the folder list in list display mode', () => {
+    const { manager, resetAndReload } = createManager({
+      displayMode: 'list',
+      foldersList: ['Civitai'],
+    });
+
+    manager.restoreSelectedFolder();
+
+    expect(manager.selectedPath).toBe('');
+    expect(resetAndReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/routes/test_misc_routes.py
+++ b/tests/routes/test_misc_routes.py
@@ -16,6 +16,7 @@ from py.routes.handlers.misc_handlers import (
     BackupHandler,
     DoctorHandler,
     FileSystemHandler,
+    HealthCheckHandler,
     LoraCodeHandler,
     ModelLibraryHandler,
     NodeRegistry,
@@ -2010,3 +2011,54 @@ async def test_resolve_filename_conflicts_handles_scanner_error_gracefully():
 
     assert payload["success"] is True
     assert payload["count"] == 0
+
+
+async def test_get_init_status_reports_complete_when_all_scanners_ready():
+    async def ready_scanner():
+        return SimpleNamespace(_cache=object(), is_initializing=lambda: False)
+
+    handler = HealthCheckHandler(
+        scanner_getters={
+            "lora": ready_scanner,
+            "recipe": ready_scanner,
+        }
+    )
+
+    response = await handler.get_init_status(FakeRequest(method="GET"))  # pyright: ignore[reportArgumentType]
+    payload = _json_payload(response)
+
+    assert payload["status"] == "complete"
+    assert payload["progress"] == 100
+    assert "pageType" not in payload
+
+
+async def test_get_init_status_reports_pending_scanners():
+    async def ready_scanner():
+        return SimpleNamespace(_cache=object(), is_initializing=lambda: False)
+
+    async def initializing_scanner():
+        return SimpleNamespace(_cache=object(), is_initializing=lambda: True)
+
+    async def no_cache_scanner():
+        return SimpleNamespace(_cache=None, is_initializing=lambda: False)
+
+    async def failing_scanner():
+        raise RuntimeError("scanner unavailable")
+
+    handler = HealthCheckHandler(
+        scanner_getters={
+            "lora": ready_scanner,
+            "checkpoint": initializing_scanner,
+            "embedding": no_cache_scanner,
+            "recipe": failing_scanner,
+        }
+    )
+
+    response = await handler.get_init_status(FakeRequest(method="GET"))  # pyright: ignore[reportArgumentType]
+    payload = _json_payload(response)
+
+    assert payload["status"] == "initializing"
+    assert "checkpoint" in payload["details"]
+    assert "embedding" in payload["details"]
+    assert "recipe" in payload["details"]
+    assert "lora" not in payload["details"]


### PR DESCRIPTION
## Problem

On a cold start (server just launched, especially while online), the Recipes page rendered completely empty — "No recipes found" and an empty folder tree — and only recovered after one or two manual browser refreshes.

## Root causes

1. **`RecipeScanner.get_cached_data()` claimed to wait for a running initialization but actually returned the placeholder empty cache** (`py/services/recipe_scanner.py`). The initializing flag was also set only *after* the LoRA scanner wait, leaving an unguarded window where every API request saw zero recipes.

2. **The recipes page had no initialization gate.** `RecipePageHandler.render_page` hardcoded `is_initializing=False`, so the page never showed the initialization screen the model pages use, and `RecipeScanner` never broadcast init progress — nothing told the page when the background scan finished, so it stayed empty until F5.

3. **`restoreSelectedFolder` trusted localStorage blindly** (`static/js/components/SidebarManager.js`). A persisted `activeFolder` pointing at a folder missing from the loaded tree left the grid filtered to a nonexistent folder with a phantom breadcrumb and no recovery path short of clicking the root breadcrumb.

## Fixes (one commit each)

- **`7fa77238`** — `get_cached_data()` now awaits the in-flight `_initialization_task` (guarded against self-await) instead of returning an empty cache; the initializing flag/task are set before the first `await` and reset in a `finally`.
- **`0b79d1bc`** — `render_page` computes `is_initializing` from scanner state like the model pages do; `RecipeScanner` broadcasts init progress with `status: 'complete'` on both success and failure (failure also seeds an empty cache so the page never stalls); `initialization.js` detects `/loras/recipes` *before* the generic `/loras` match and maps `scanner_type: 'recipe'` → `recipes`. The cached-progress replay in `WebSocketManager` covers clients that connect after the scan already finished.
- **`6e96ae1e`** — `restoreSelectedFolder` validates the persisted folder against the freshly loaded tree and falls back to root (also resetting `pageState.activeFolder` and localStorage) when it no longer exists; validation is skipped when the tree load failed so transient API errors don't wipe the saved location.

## Verification

- Backend: `pytest` — 2293 passed, 11 deselected
- Frontend: `npm run test:js` — 78 files, 682 passed