### PR TITLE
re-enable disabled LoRAs sent from the manager

### DIFF
--- a/tests/frontend/components/loraLoader.activateDisabled.test.js
+++ b/tests/frontend/components/loraLoader.activateDisabled.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const {
+  APP_MODULE,
+  API_MODULE,
+  UTILS_MODULE,
+  LORA_LOADER_MODULE,
+} = vi.hoisted(() => ({
+  APP_MODULE: new URL("../../../scripts/app.js", import.meta.url).pathname,
+  API_MODULE: new URL("../../../scripts/api.js", import.meta.url).pathname,
+  UTILS_MODULE: new URL("../../../web/comfyui/utils.js", import.meta.url).pathname,
+  LORA_LOADER_MODULE: new URL("../../../web/comfyui/lora_loader.js", import.meta.url).pathname,
+}));
+
+const extensionState = { current: null };
+const registerExtensionMock = vi.fn((extension) => {
+  extensionState.current = extension;
+});
+
+vi.mock(APP_MODULE, () => ({
+  app: {
+    registerExtension: registerExtensionMock,
+    graph: {},
+  },
+}));
+
+vi.mock(API_MODULE, () => ({
+  api: {
+    addEventListener: vi.fn(),
+  },
+}));
+
+const collectActiveLorasFromChain = vi.fn(() => new Set());
+const updateConnectedTriggerWords = vi.fn();
+const getAllGraphNodes = vi.fn(() => []);
+const getNodeFromGraph = vi.fn();
+const getWidgetByName = vi.fn();
+const getWidgetSerializedValue = vi.fn();
+
+// Mirrors the real merge: LoRAs already on the node keep their saved state
+const mergeLoras = vi.fn((lorasText, lorasArr) => {
+  const parsed = {};
+  const pattern = /<lora:([^:]+):([-\d.]+)(?::([-\d.]+))?>/g;
+  let match;
+  while ((match = pattern.exec(lorasText || "")) !== null) {
+    parsed[match[1]] = Number(match[2]);
+  }
+
+  const result = [];
+  const used = new Set();
+  for (const lora of lorasArr) {
+    if (parsed[lora.name] !== undefined) {
+      result.push({
+        ...lora,
+        active: lora.active !== undefined ? lora.active : true,
+      });
+      used.add(lora.name);
+    }
+  }
+  for (const name of Object.keys(parsed)) {
+    if (!used.has(name)) {
+      result.push({ name, strength: parsed[name], active: true });
+    }
+  }
+  return result;
+});
+
+vi.mock(UTILS_MODULE, () => ({
+  collectActiveLorasFromChain,
+  updateConnectedTriggerWords,
+  mergeLoras,
+  chainCallback: (proto, property, callback) => {
+    proto[property] = callback;
+  },
+  getAllGraphNodes,
+  getNodeFromGraph,
+  getWidgetByName,
+  getWidgetSerializedValue,
+  LORA_PATTERN: /<lora:([^:]+):([-\d.]+)(?::([-\d.]+))?>/g,
+}));
+
+function createNode(loras) {
+  const inputWidget = {
+    name: "text",
+    value: loras.map((lora) => `<lora:${lora.name}:${lora.strength ?? 1}>`).join(" "),
+    callback: null,
+  };
+
+  const lorasWidget = {
+    value: loras,
+    callback: vi.fn(),
+  };
+
+  // Same wiring onNodeCreated installs: text edits are merged into the widget
+  inputWidget.callback = (value) => {
+    lorasWidget.value = mergeLoras(value, lorasWidget.value || []);
+  };
+
+  return {
+    comfyClass: "Lora Loader (LoraManager)",
+    inputWidget,
+    lorasWidget,
+  };
+}
+
+describe("Lora Loader re-enables disabled LoRAs sent from the manager", () => {
+  beforeEach(() => {
+    vi.resetModules();
+
+    extensionState.current = null;
+    registerExtensionMock.mockClear();
+
+    collectActiveLorasFromChain.mockClear();
+    updateConnectedTriggerWords.mockClear();
+    mergeLoras.mockClear();
+    getNodeFromGraph.mockReset();
+    getAllGraphNodes.mockReset();
+    getAllGraphNodes.mockReturnValue([]);
+  });
+
+  it("activates a LoRA that is already on the node but toggled off", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const node = createNode([
+      { name: "Alpha", strength: 0.8, active: false },
+      { name: "Beta", strength: 1, active: false },
+    ]);
+    getNodeFromGraph.mockReturnValue(node);
+
+    extension.handleLoraCodeUpdate({
+      node_id: 5,
+      lora_code: "<lora:Alpha:1.00>",
+      mode: "append",
+    });
+
+    const alpha = node.lorasWidget.value.find((lora) => lora.name === "Alpha");
+    const beta = node.lorasWidget.value.find((lora) => lora.name === "Beta");
+
+    expect(alpha.active).toBe(true);
+    // The saved strength is kept and unrelated LoRAs are left untouched
+    expect(alpha.strength).toBe(0.8);
+    expect(beta.active).toBe(false);
+    expect(node.lorasWidget.callback).toHaveBeenCalledWith(node.lorasWidget.value);
+  });
+
+  it("re-enables the LoRA in replace mode as well", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const node = createNode([{ name: "Alpha", strength: 0.5, active: false }]);
+    getNodeFromGraph.mockReturnValue(node);
+
+    extension.handleLoraCodeUpdate({
+      node_id: 5,
+      lora_code: "<lora:Alpha:1.00>",
+      mode: "replace",
+    });
+
+    expect(node.lorasWidget.value[0].active).toBe(true);
+  });
+
+  it("re-enables every LoRA of a recipe sent at once", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const node = createNode([
+      { name: "Alpha", strength: 1, active: false },
+      { name: "Beta", strength: 1, active: false },
+    ]);
+    getNodeFromGraph.mockReturnValue(node);
+
+    extension.handleLoraCodeUpdate({
+      node_id: 5,
+      lora_code: "<lora:Alpha:1.00> <lora:Beta:0.70>",
+      mode: "append",
+    });
+
+    expect(node.lorasWidget.value.every((lora) => lora.active === true)).toBe(true);
+  });
+
+  it("leaves the widget alone when the sent LoRA is already active", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const node = createNode([{ name: "Alpha", strength: 1, active: true }]);
+    getNodeFromGraph.mockReturnValue(node);
+
+    extension.handleLoraCodeUpdate({
+      node_id: 5,
+      lora_code: "<lora:Alpha:1.00>",
+      mode: "append",
+    });
+
+    expect(node.lorasWidget.value[0].active).toBe(true);
+    expect(node.lorasWidget.callback).not.toHaveBeenCalled();
+  });
+
+  it("does not touch disabled LoRAs that were not sent", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const node = createNode([{ name: "Alpha", strength: 1, active: false }]);
+    getNodeFromGraph.mockReturnValue(node);
+
+    extension.handleLoraCodeUpdate({
+      node_id: 5,
+      lora_code: "<lora:Gamma:1.00>",
+      mode: "append",
+    });
+
+    const names = node.lorasWidget.value.map((lora) => lora.name);
+    expect(names).toContain("Gamma");
+    expect(node.lorasWidget.value.find((lora) => lora.name === "Alpha").active).toBe(false);
+  });
+
+  it("activates disabled LoRAs on every node in broadcast mode", async () => {
+    await import(LORA_LOADER_MODULE);
+    const extension = extensionState.current;
+
+    const first = createNode([{ name: "Alpha", strength: 1, active: false }]);
+    const second = createNode([{ name: "Alpha", strength: 1, active: false }]);
+    getAllGraphNodes.mockReturnValue([{ node: first }, { node: second }]);
+
+    extension.handleLoraCodeUpdate({
+      node_id: -1,
+      lora_code: "<lora:Alpha:1.00>",
+      mode: "append",
+    });
+
+    expect(first.lorasWidget.value[0].active).toBe(true);
+    expect(second.lorasWidget.value[0].active).toBe(true);
+  });
+});

--- a/web/comfyui/lora_loader.js
+++ b/web/comfyui/lora_loader.js
@@ -9,6 +9,7 @@ import {
   getNodeFromGraph,
   getWidgetByName,
   getWidgetSerializedValue,
+  LORA_PATTERN,
 } from "./utils.js";
 import { applyLoraValuesToText, debounce } from "./lora_syntax_utils.js";
 
@@ -104,6 +105,46 @@ app.registerExtension({
     // Trigger the callback to update the loras widget
     if (typeof inputWidget.callback === "function") {
       inputWidget.callback(inputWidget.value);
+    }
+
+    // mergeLoras keeps the saved state of LoRAs that are already on the node,
+    // so re-enable the ones that were just sent. Otherwise sending a LoRA that
+    // is present but toggled off would silently do nothing.
+    this.activateLorasFromCode(node, loraCode);
+  },
+
+  // Turn on the toggle of every LoRA referenced by loraCode that already
+  // exists on the node but is currently disabled
+  activateLorasFromCode(node, loraCode) {
+    const lorasWidget = node.lorasWidget;
+    if (!lorasWidget || !loraCode) return;
+
+    const names = new Set();
+    let match;
+    LORA_PATTERN.lastIndex = 0;
+    while ((match = LORA_PATTERN.exec(loraCode)) !== null) {
+      names.add(match[1]);
+    }
+    if (names.size === 0) return;
+
+    const currentLoras = Array.isArray(lorasWidget.value) ? lorasWidget.value : [];
+    let changed = false;
+    const updatedLoras = currentLoras.map((lora) => {
+      if (lora && names.has(lora.name) && lora.active !== true) {
+        changed = true;
+        return { ...lora, active: true };
+      }
+      return lora;
+    });
+
+    if (!changed) return;
+
+    lorasWidget.value = updatedLoras;
+
+    // Mirrors the manual toggle: the widget setter re-renders, the callback
+    // refreshes trigger words and syncs the text widget
+    if (typeof lorasWidget.callback === "function") {
+      lorasWidget.callback(lorasWidget.value);
     }
   },
 


### PR DESCRIPTION
Sending a LoRA to a lora manager node that already contains it but with the toggle switched off had no visible effect 
When a lora is on the lora manager node, but disabled, and there are lots of other loras, and lora names on lora manager node are not always are intuitive, 
If you just want to locate a lora in the lora manager which is already there to activate it,  is just difficult

With this change just open Lora Manager page, locate the lora and send it to the workflow, the lora which is already in the lora manager node will activate, making super easy to locate the lora
