### PR TITLE
fix: preserve source-independent trigger words across catalog and cache

### DIFF
--- a/py/services/checkpoint_service.py
+++ b/py/services/checkpoint_service.py
@@ -57,6 +57,7 @@ class CheckpointService(BaseModelService):
             "modified": model_data.get("modified", ""),
             "tags": model_data.get("tags", []),
             "from_civitai": model_data.get("from_civitai", True),
+            "trainedWords": model_data.get("trainedWords", []),
             "usage_count": model_data.get("usage_count", 0),
             "notes": model_data.get("notes", ""),
             "sub_type": sub_type,

--- a/py/services/embedding_service.py
+++ b/py/services/embedding_service.py
@@ -57,6 +57,7 @@ class EmbeddingService(BaseModelService):
             "modified": model_data.get("modified", ""),
             "tags": model_data.get("tags", []),
             "from_civitai": model_data.get("from_civitai", True),
+            "trainedWords": model_data.get("trainedWords", []),
             # "usage_count": model_data.get("usage_count", 0), # TODO: Enable when embedding usage tracking is implemented
             "notes": model_data.get("notes", ""),
             "sub_type": sub_type,

--- a/py/services/lora_service.py
+++ b/py/services/lora_service.py
@@ -64,6 +64,7 @@ class LoraService(BaseModelService):
             "modified": model_data.get("modified", ""),
             "tags": model_data.get("tags", []),
             "from_civitai": model_data.get("from_civitai", True),
+            "trainedWords": model_data.get("trainedWords", []),
             "usage_count": model_data.get("usage_count", 0),
             "usage_tips": model_data.get("usage_tips", ""),
             "notes": model_data.get("notes", ""),
@@ -282,7 +283,7 @@ class LoraService(BaseModelService):
             file_name = lora.get("file_name", "")
             if file_name == lora_name or lora_name.endswith("/" + file_name) or lora_name.endswith("\\" + file_name):
                 civitai_data = lora.get("civitai") or {}
-                return civitai_data.get("trainedWords", [])
+                return lora.get("trainedWords") or civitai_data.get("trainedWords", [])
 
         return []
 

--- a/py/services/model_scanner.py
+++ b/py/services/model_scanner.py
@@ -331,6 +331,9 @@ class ModelScanner:
 
         civitai_full = get_value('civitai')
         civitai_slim = self._slim_civitai_payload(civitai_full)
+        trained_words = get_value('trainedWords')
+        if not isinstance(trained_words, list):
+            trained_words = []
         usage_tips = get_value('usage_tips', '') or ''
         if not isinstance(usage_tips, str):
             usage_tips = str(usage_tips)
@@ -377,6 +380,9 @@ class ModelScanner:
             'db_checked': bool(get_value('db_checked', False)),
             'last_checked_at': float(get_value('last_checked_at', 0.0) or 0.0),
             'tags': tags_list,
+            # Local and Hugging Face models can declare activation words without
+            # a Civitai payload. Keep these independent of provider metadata.
+            'trainedWords': list(trained_words),
             'civitai': civitai_slim,
             'civitai_deleted': bool(get_value('civitai_deleted', False)),
             'skip_metadata_refresh': bool(get_value('skip_metadata_refresh', False)),

--- a/py/services/persistent_model_cache.py
+++ b/py/services/persistent_model_cache.py
@@ -52,6 +52,7 @@ class PersistentModelCache:
         "civitai_name",
         "civitai_creator_username",
         "trained_words",
+        "model_trained_words",
         "license_flags",
         "civitai_deleted",
         "skip_metadata_refresh",
@@ -170,6 +171,13 @@ class PersistentModelCache:
             if license_value is None:
                 license_value = DEFAULT_LICENSE_FLAGS
 
+            try:
+                model_trained_words = json.loads(row["model_trained_words"] or "[]")
+            except (json.JSONDecodeError, TypeError):
+                model_trained_words = []
+            if not isinstance(model_trained_words, list):
+                model_trained_words = []
+
             item = {
                 "file_path": file_path,
                 "file_name": row["file_name"] or "",
@@ -190,6 +198,7 @@ class PersistentModelCache:
                 "db_checked": bool(row["db_checked"]),
                 "last_checked_at": row["last_checked_at"] or 0.0,
                 "tags": tags.get(file_path, []),
+                "trainedWords": model_trained_words,
                 "civitai": civitai,
                 "civitai_deleted": bool(row["civitai_deleted"]),
                 "skip_metadata_refresh": bool(row["skip_metadata_refresh"]),
@@ -519,6 +528,7 @@ class PersistentModelCache:
                             civitai_name TEXT,
                             civitai_creator_username TEXT,
                             trained_words TEXT,
+                            model_trained_words TEXT DEFAULT '[]',
                             civitai_deleted INTEGER,
                             exclude INTEGER,
                             db_checked INTEGER,
@@ -573,6 +583,7 @@ class PersistentModelCache:
 
         required_columns = {
             "metadata_source": "TEXT",
+            "model_trained_words": "TEXT DEFAULT '[]'",
             "civitai_creator_username": "TEXT",
             "civitai_model_type": "TEXT",
             "civitai_deleted": "INTEGER DEFAULT 0",
@@ -657,6 +668,7 @@ class PersistentModelCache:
             civitai.get("name"),
             creator_username,
             trained_words_json,
+            json.dumps(item.get("trainedWords") or []),
             int(license_flags),
             1 if item.get("civitai_deleted") else 0,
             1 if item.get("skip_metadata_refresh") else 0,

--- a/tests/services/test_local_trigger_words.py
+++ b/tests/services/test_local_trigger_words.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from py.services.lora_service import LoraService
+from py.services.checkpoint_service import CheckpointService
+from py.services.embedding_service import EmbeddingService
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_class", [LoraService, CheckpointService, EmbeddingService])
+async def test_catalog_response_exposes_local_trigger_words(service_class) -> None:
+    scanner = SimpleNamespace()
+    service = service_class(scanner)
+    response = await service.format_response({
+        "file_path": "/models/local.safetensors", "file_name": "local", "model_name": "Local",
+        "trainedWords": ["subject1"], "from_civitai": False, "civitai": {},
+    })
+    assert response["trainedWords"] == ["subject1"]
+    assert not response["civitai"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_lookup_prefers_local_words_and_keeps_legacy_fallback() -> None:
+    item = {"file_name": "local", "trainedWords": ["subject1"], "civitai": {"trainedWords": ["legacy"]}}
+    scanner = SimpleNamespace(get_cached_data=AsyncMock(return_value=SimpleNamespace(raw_data=[item])))
+    service = LoraService(scanner)
+    assert await service.get_lora_trigger_words("local") == ["subject1"]
+    item["trainedWords"] = []
+    assert await service.get_lora_trigger_words("local") == ["legacy"]

--- a/tests/services/test_model_scanner.py
+++ b/tests/services/test_model_scanner.py
@@ -97,6 +97,23 @@ class MultiRootDummyScanner(DummyScanner):
         return list(self._roots)
 
 
+@pytest.mark.parametrize("as_metadata_object", [False, True])
+@pytest.mark.asyncio
+async def test_cache_entry_preserves_source_independent_trigger_words(tmp_path: Path, as_metadata_object: bool) -> None:
+    source = {
+        "file_name": "local", "model_name": "Local model", "file_path": str(tmp_path / "local.txt"),
+        "size": 1, "modified": 0.0, "sha256": "abc", "base_model": "Unknown", "preview_url": "",
+        "from_civitai": False, "trainedWords": ["local subject", "style"], "civitai": {},
+    }
+    metadata = BaseModelMetadata.from_dict(source) if as_metadata_object else source
+    scanner = DummyScanner(tmp_path)
+    entry = scanner._build_cache_entry(metadata)
+    assert entry["trainedWords"] == ["local subject", "style"]
+    assert not entry["civitai"]
+    entry["trainedWords"].append("cache-only change")
+    assert source["trainedWords"] == ["local subject", "style"]
+
+
 @pytest.fixture(autouse=True)
 def reset_model_scanner_singletons():
     ModelScanner._instances.clear()
@@ -837,6 +854,7 @@ def _make_cache_entry(**overrides) -> Dict[str, Any]:
         "db_checked": False,
         "last_checked_at": 0.0,
         "tags": ["alpha"],
+        "trainedWords": [],
         "civitai": {"id": 111, "modelId": 222, "name": "v1"},
         "civitai_deleted": False,
         "skip_metadata_refresh": False,

--- a/tests/services/test_persistent_model_cache.py
+++ b/tests/services/test_persistent_model_cache.py
@@ -1,9 +1,36 @@
 from pathlib import Path
 from typing import Any, Dict
+import sqlite3
 
 import pytest
 
 from py.services.persistent_model_cache import PersistentModelCache, DEFAULT_LICENSE_FLAGS
+
+
+def test_source_independent_trigger_words_survive_restart_and_migration(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv('LORA_MANAGER_DISABLE_PERSISTENT_CACHE', '0')
+    db_path = str(tmp_path / 'cache.sqlite')
+    store = PersistentModelCache(db_path=db_path)
+    path = (tmp_path / 'local.safetensors').as_posix()
+    item = {'file_path': path, 'trainedWords': ['local subject'], 'from_civitai': False, 'civitai': None}
+    store.save_cache('lora', [item], {}, [])
+    restored = PersistentModelCache(db_path=db_path).load_cache('lora').raw_data[0]
+    assert restored['trainedWords'] == ['local subject']
+    assert restored['civitai'] is None
+
+    # Provider words and local words must not overwrite or masquerade as one another.
+    item['civitai'] = {'id': 123, 'trainedWords': ['provider style']}
+    store.update_single_model('lora', item)
+    restored = PersistentModelCache(db_path=db_path).load_cache('lora').raw_data[0]
+    assert restored['trainedWords'] == ['local subject']
+    assert restored['civitai']['trainedWords'] == ['provider style']
+
+    # Simulate the previous schema: migration keeps existing rows/provider words.
+    with sqlite3.connect(db_path) as connection:
+        connection.execute('ALTER TABLE models DROP COLUMN model_trained_words')
+    restored = PersistentModelCache(db_path=db_path).load_cache('lora').raw_data[0]
+    assert restored['trainedWords'] == []
+    assert restored['civitai']['trainedWords'] == ['provider style']
 
 
 def test_persistent_cache_roundtrip(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem
BaseModelMetadata supports top-level trainedWords, but the scanner projection drops them and the persistent cache only stores civitai.trainedWords. Catalog responses and the LoRA trigger lookup therefore lose activation words for locally trained or other non-Civitai models.

## Changes
- Preserve top-level trainedWords separately from provider metadata in the scanner and model catalog responses.
- Persist them in a dedicated additive SQLite column with an empty-list migration default. Keep legacy Civitai words intact.
- Prefer local words in the LoRA trigger lookup, retaining the existing Civitai fallback.
- Add mapping/dataclass projection, response, lookup, independent provider/local round-trip, update, and old-schema migration regressions.

## Verification
- 60 focused Python tests passed across model scanner, persistent model cache, and local trigger words.
- Isolated standalone integration with two local synthetic safetensors fixtures passed discovery, search, trigger-word retention, rescan, unavailable-service detection, and process restart. No real model downloads or user library changes.

The schema migration cannot recover words already omitted from an old cache; a rescan reads them from existing sidecars. No browser-extension code or private application data is included.